### PR TITLE
fix: responsive mobile layout for CTA form (#24)

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -831,7 +831,7 @@ export default function Home() {
       {/* 12. Final CTA Form */}
       <section id="cta" className="py-24 border-t border-slate-900 relative">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid lg:grid-cols-2 gap-16 items-center bg-slate-950 p-12 rounded-[3rem] border border-slate-800 shadow-2xl overflow-hidden relative">
+          <div className="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center bg-slate-950 p-6 sm:p-8 lg:p-12 rounded-2xl lg:rounded-[3rem] border border-slate-800 shadow-2xl overflow-hidden relative">
             <div className="absolute top-0 right-0 w-64 h-64 bg-blue-600/10 blur-[100px] rounded-full -z-10" />
             
             <div>
@@ -862,9 +862,9 @@ export default function Home() {
               </div>
             </div>
 
-            <div className="bg-slate-900/50 p-8 rounded-3xl border border-slate-800 backdrop-blur-sm">
+            <div className="bg-slate-900/50 p-5 sm:p-8 rounded-2xl sm:rounded-3xl border border-slate-800 backdrop-blur-sm">
               <form className="space-y-4" onSubmit={handleSubmit}>
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div>
                     <label className="block text-xs font-bold text-slate-500 uppercase tracking-widest mb-2 ml-1">Имя</label>
                     <input name="name" type="text" className="w-full bg-slate-950 border border-slate-800 rounded-xl px-4 py-3 text-slate-100 focus:border-blue-500 outline-none transition-all" placeholder="Александр" />


### PR DESCRIPTION
Fixes #24

## Проблемы и исправления

| Элемент | Было | Стало |
|---|---|---|
| Внешний контейнер | `p-12 rounded-[3rem]` | `p-6 sm:p-8 lg:p-12 rounded-2xl lg:rounded-[3rem]` |
| Карточка формы | `p-8 rounded-3xl` | `p-5 sm:p-8 rounded-2xl sm:rounded-3xl` |
| Поля Имя / Компания | `grid-cols-2` (всегда) | `grid-cols-1 sm:grid-cols-2` (1 колонка на мобиле) |
| Gap между колонками | `gap-16` | `gap-10 lg:gap-16` |