### PR TITLE
fix: rework project to run at website root instead of /cicle/

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -18,4 +18,4 @@ export const router = createBrowserRouter([
       },
     ],
   },
-], { basename: '/cicle' })
+])

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/cicle/',
+  base: '/',
 
   plugins: [
     react(),


### PR DESCRIPTION
## Summary

Fixes #34 — project was hardcoded to run under `/cicle/` subfolder; reworked to serve from the website root.

**Changes:**
- `vite.config.ts`: `base: '/cicle/'` → `base: '/'`
- `src/router.tsx`: removed `{ basename: '/cicle' }` from `createBrowserRouter`

## Test plan
- [ ] Build (`npm run build`) produces assets with correct root-relative paths
- [ ] App loads correctly at `https://example.com/` (not `https://example.com/cicle/`)
- [ ] Internal navigation works from root

🤖 Generated with [Claude Code](https://claude.com/claude-code)