### PR TITLE
feat: add /success payment confirmation page

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -24,10 +24,10 @@ export function Footer() {
           <div>
             <h3 className="text-slate-800 dark:text-slate-100 font-semibold mb-6">Продукт</h3>
             <ul className="space-y-4">
-              <li><a href="#technology" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Технология</a></li>
-              <li><a href="#process" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Схема работы</a></li>
-              <li><a href="#cases" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Примеры</a></li>
-              <li><a href="#pricing" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Стоимость</a></li>
+              <li><a href="/#technology" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Технология</a></li>
+              <li><a href="/#process" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Схема работы</a></li>
+              <li><a href="/#cases" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Примеры</a></li>
+              <li><a href="/#pricing" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Стоимость</a></li>
             </ul>
           </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,10 +9,10 @@ export function Header() {
   const { theme, toggleTheme } = useTheme()
 
   const navLinks = [
-    { name: 'Технология', href: '#technology' },
-    { name: 'Как работаем', href: '#process' },
-    { name: 'Примеры', href: '#cases' },
-    { name: 'Цены', href: '#pricing' },
+    { name: 'Технология', href: '/#technology' },
+    { name: 'Как работаем', href: '/#process' },
+    { name: 'Примеры', href: '/#cases' },
+    { name: 'Цены', href: '/#pricing' },
   ]
 
   return (
@@ -45,7 +45,7 @@ export function Header() {
               {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
             </button>
             <a
-              href="#cta"
+              href="/#cta"
               className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-lg transition-all"
             >
               Заказать демо
@@ -91,7 +91,7 @@ export function Header() {
             ))}
             <div className="pt-4 px-3">
               <a
-                href="#cta"
+                href="/#cta"
                 onClick={() => setIsOpen(false)}
                 className="flex items-center justify-center w-full px-4 py-3 bg-blue-600 text-white font-semibold rounded-lg"
               >

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -1,0 +1,53 @@
+import { Link } from 'react-router-dom'
+import { CheckCircle2, Mail, Phone, Send } from 'lucide-react'
+
+export default function Success() {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-6 py-32">
+      <div className="max-w-lg w-full text-center space-y-8">
+        <div className="flex justify-center">
+          <CheckCircle2 className="w-20 h-20 text-green-500" strokeWidth={1.5} />
+        </div>
+
+        <div className="space-y-4">
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-50">
+            Спасибо! Оплата завершена успешно.
+          </h1>
+          <p className="text-slate-500 dark:text-slate-400 text-lg leading-relaxed">
+            Мы свяжемся с вами в ближайшее время для продолжения сотрудничества.
+            <br />
+            Также вы можете связаться с нами по телефону или почте, указанным ниже.
+          </p>
+        </div>
+
+        <div className="flex flex-col items-center gap-3 text-sm">
+          <a
+            href="https://t.me/qdmadept"
+            className="flex items-center gap-2 text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
+          >
+            <Send size={16} /> @qdmadept
+          </a>
+          <a
+            href="mailto:abc@integram.io"
+            className="flex items-center gap-2 text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
+          >
+            <Mail size={16} /> abc@integram.io
+          </a>
+          <a
+            href="tel:+79955060167"
+            className="flex items-center gap-2 text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
+          >
+            <Phone size={16} /> +7 (995) 506-01-67
+          </a>
+        </div>
+
+        <Link
+          to="/"
+          className="inline-block px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors"
+        >
+          На главную
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom'
 import Home from './pages/Home'
 import NotFound from './pages/NotFound'
+import Success from './pages/Success'
 import App from './App'
 
 export const router = createBrowserRouter([
@@ -11,6 +12,10 @@ export const router = createBrowserRouter([
       {
         index: true,
         element: <Home />,
+      },
+      {
+        path: 'success',
+        element: <Success />,
       },
       {
         path: '*',


### PR DESCRIPTION
## Summary

Fixes #36

### Changes

**New page `src/pages/Success.tsx`** — payment success screen at `/success`:
- Header: **«Спасибо! Оплата завершена успешно.»**
- Body: «Мы свяжемся с вами в ближайшее время для продолжения сотрудничества. Также вы можете связаться с нами по телефону или почте, указанным ниже.»
- Contact links (Telegram, email, phone) from the standard footer contacts
- «На главную» button linking back to `/`
- Uses the same App layout (Header + Footer) so the page looks identical to the rest of the site

**Router (`src/router.tsx`)** — added `/success` route as a child of the root `App` layout

**Header & Footer (`src/components/Header.tsx`, `src/components/Footer.tsx`)** — updated all local anchor links from `#section` → `/#section` so that clicking any nav/footer item from the success page (or any other non-home route) correctly navigates to the home page, as required by the issue

## Test plan
- [ ] Visit `/success` — page renders with correct title, text and contacts
- [ ] Click "Заказать демо" from the success page — redirects to `/#cta` on home
- [ ] Click any nav link (Технология, Цены, etc.) from the success page — goes to home with scroll to that section
- [ ] Logo click → `/`
- [ ] "На главную" button → `/`
- [ ] Home page: anchor links still scroll correctly (ScrollToHash in App.tsx handles `/#section`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)