### PR TITLE
Add local development instructions for VS Code

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-04-09T21:05:23.274Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-04-09T21:05:23.274Z

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a template project with Vite, React, TypeScript, Tailwind CSS, and shadc
 
 ## Project Structure
 
-\`\`\`
+```
 src/
 ├── components/
 │   └── ui/          # shadcn/ui components
@@ -21,4 +21,65 @@ src/
 ├── App.tsx          # Main application component
 ├── main.tsx         # Entry point
 └── index.css        # Global styles with Tailwind
-\`\`\`
+```
+
+## Running Locally in VS Code
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (v18 or later recommended)
+- [VS Code](https://code.visualstudio.com/)
+
+### Steps
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/ideav/backlogram
+   cd backlogram
+   ```
+
+2. **Open in VS Code**
+
+   Use the menu: `File → Open Folder → backlogram`
+
+   Or from the terminal:
+   ```bash
+   code .
+   ```
+
+3. **Open the integrated terminal**
+
+   Press `` Ctrl+` `` (backtick) to open the terminal inside VS Code.
+
+4. **Install dependencies and start the dev server**
+
+   For the main app (root):
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+   For the blog app (`blog/` subdirectory):
+   ```bash
+   cd blog
+   npm install
+   npm run dev
+   ```
+
+5. **Open in browser**
+
+   The app will be available at: [http://localhost:5173](http://localhost:5173)
+
+### Recommended VS Code Extensions
+
+- **ESLint** — JavaScript/TypeScript linting
+- **Tailwind CSS IntelliSense** — Autocomplete for Tailwind classes
+- **TypeScript Vue Plugin** — Better TypeScript support
+
+### Tech Stack
+
+- [Vite](https://vitejs.dev/) — build tool and dev server
+- [React 18](https://react.dev/) — UI framework
+- [TypeScript](https://www.typescriptlang.org/) — type safety
+- [Tailwind CSS](https://tailwindcss.com/) — utility-first styling
+- [shadcn/ui](https://ui.shadcn.com/) — component library


### PR DESCRIPTION
## Summary

- Adds a **"Running Locally in VS Code"** section to `README.md` answering issue #74
- Covers both the root app and the `blog/` subdirectory app
- Includes step-by-step instructions: clone → open in VS Code → install deps → start dev server → open browser
- Lists recommended VS Code extensions (ESLint, Tailwind CSS IntelliSense, TypeScript)
- Adds tech stack links for quick reference

## How to verify

```bash
git clone https://github.com/ideav/backlogram
cd backlogram
npm install
npm run dev
# open http://localhost:5173
```

Closes #74

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)