### PR TITLE
feat: add personal data consent checkbox to #cta form (#78)

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -27,6 +27,7 @@ type FormState = 'idle' | 'sending' | 'success' | 'error'
 export default function Home() {
   const [formState, setFormState] = React.useState<FormState>('idle')
   const [errorMsg, setErrorMsg]   = React.useState('')
+  const [consentChecked, setConsentChecked] = React.useState(false)
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -874,9 +875,28 @@ export default function Home() {
                   <div className="text-red-500 dark:text-red-400 text-sm font-medium">{errorMsg}</div>
                 )}
 
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={consentChecked}
+                    onChange={e => setConsentChecked(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 shrink-0 rounded border-slate-300 dark:border-slate-600 accent-blue-600 cursor-pointer"
+                  />
+                  <span className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
+                    Я даю согласие на{' '}
+                    <a
+                      href="/privacy"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-blue-500 transition-colors"
+                    >
+                      обработку персональных данных
+                    </a>
+                  </span>
+                </label>
                 <button
                   type="submit"
-                  disabled={formState === 'sending' || formState === 'success'}
+                  disabled={formState === 'sending' || formState === 'success' || !consentChecked}
                   className="w-full py-3 sm:py-4 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-xl shadow-lg shadow-blue-600/20 transition-all flex items-center justify-center gap-2"
                 >
                   {formState === 'sending' ? 'Отправка...' : 'Отправить на оценку'}


### PR DESCRIPTION
## Summary

- Added a checkbox with consent text above the submit button in the `#cta` form
- Text: **«Я даю согласие на обработку персональных данных»** with a link to `/privacy`
- Submit button is disabled until the checkbox is checked (`!consentChecked`)
- New state: `consentChecked` (`boolean`, default `false`)

## Test plan

- [ ] Open the landing page, scroll to the `#cta` form
- [ ] Verify the consent checkbox and text appear above the submit button
- [ ] Verify the submit button is disabled by default (greyed out)
- [ ] Check the checkbox — submit button should become active
- [ ] Uncheck — button should disable again
- [ ] Click the "обработку персональных данных" link — should open `/privacy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)