### PR TITLE
feat: add client logos grid section to homepage (#82)

### DIFF
--- a/src/components/ClientLogos.tsx
+++ b/src/components/ClientLogos.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { motion } from 'framer-motion'
+
+const CLIENTS = [
+  { name: 'БМТ' },
+  { name: 'Neoflex' },
+  { name: "Domino's" },
+  { name: 'Audi' },
+  { name: 'Rlink' },
+  { name: 'UpSound' },
+  { name: 'ПроВе' },
+  { name: 'BAIR' },
+  { name: 'Milka' },
+  { name: 'ПМК-178 Бетон' },
+  { name: 'Торнон' },
+  { name: 'ГидроБот' },
+]
+
+export default function ClientLogos() {
+  return (
+    <section className="py-16 border-t border-slate-200 dark:border-slate-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <p className="text-center text-xs font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-10">
+          Используют нашу платформу
+        </p>
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+          className="flex flex-wrap justify-center gap-3 sm:gap-4"
+        >
+          {CLIENTS.map((client) => (
+            <div
+              key={client.name}
+              className="px-5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 text-slate-500 dark:text-slate-400 text-sm font-semibold tracking-wide hover:border-slate-300 dark:hover:border-slate-700 hover:text-slate-700 dark:hover:text-slate-300 transition-all"
+            >
+              {client.name}
+            </div>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,6 +21,7 @@ import {
   MessageSquare
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
+import ClientLogos from '@/components/ClientLogos'
 
 type FormState = 'idle' | 'sending' | 'success' | 'error'
 
@@ -126,6 +127,9 @@ export default function Home() {
           </div>
         </div>
       </section>
+
+      {/* 1b. Client Logos */}
+      <ClientLogos />
 
       {/* 2. Problem Section */}
       <section className="py-24 bg-slate-50 dark:bg-slate-900/50 relative">


### PR DESCRIPTION
## Summary

Adds a new `ClientLogos` component displaying 12 client companies in a consistent badge-grid style, inserted between the Hero and Problem sections.

**Companies shown:** БМТ, Neoflex, Domino's, Audi, Rlink, UpSound, ПроВе, BAIR, Milka, ПМК-178 Бетон, Торнон, ГидроБот

**Design decisions:**
- Pill-shaped badges with consistent border + background — same style for all brands
- Muted text color (`slate-500`) on light/dark backgrounds — neutral, professional
- `flex-wrap` grid adapts from mobile to desktop
- Fade-in animation with `framer-motion` `whileInView` on first scroll
- Section label: «Используют нашу платформу» in small caps

## Test plan

- [ ] Logos section appears between Hero and Problem sections
- [ ] All 12 company names render correctly
- [ ] Responsive: wraps gracefully on mobile
- [ ] Dark mode: borders and text switch correctly
- [ ] Fade-in triggers on first scroll into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)