### PR TITLE
fix: logos in single scrollable row (#89)

### DIFF
--- a/src/components/ClientLogos.tsx
+++ b/src/components/ClientLogos.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { motion } from 'framer-motion'
 
 const CLIENTS = [
@@ -19,6 +19,28 @@ const CLIENTS = [
 ]
 
 export default function ClientLogos() {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const isDragging = useRef(false)
+  const startX = useRef(0)
+  const scrollLeft = useRef(0)
+
+  function onMouseDown(e: React.MouseEvent) {
+    isDragging.current = true
+    startX.current = e.pageX - (scrollRef.current?.offsetLeft ?? 0)
+    scrollLeft.current = scrollRef.current?.scrollLeft ?? 0
+  }
+
+  function onMouseMove(e: React.MouseEvent) {
+    if (!isDragging.current || !scrollRef.current) return
+    e.preventDefault()
+    const x = e.pageX - scrollRef.current.offsetLeft
+    scrollRef.current.scrollLeft = scrollLeft.current - (x - startX.current)
+  }
+
+  function stopDrag() {
+    isDragging.current = false
+  }
+
   return (
     <section className="py-16 border-t border-slate-200 dark:border-slate-800">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -26,25 +48,33 @@ export default function ClientLogos() {
           Воспользовались опытом команды и нашими решениями
         </p>
         <motion.div
+          ref={scrollRef}
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
-          className="flex flex-wrap justify-center gap-4"
+          className="overflow-x-auto select-none cursor-grab active:cursor-grabbing"
+          onMouseDown={onMouseDown}
+          onMouseMove={onMouseMove}
+          onMouseUp={stopDrag}
+          onMouseLeave={stopDrag}
         >
-          {CLIENTS.map((client) => (
-            <div
-              key={client.name}
-              title={client.name}
-              className="w-28 h-16 flex items-center justify-center rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-sm transition-all"
-            >
-              <img
-                src={client.logo}
-                alt={client.name}
-                className="w-full h-full object-contain"
-              />
-            </div>
-          ))}
+          <div className="flex gap-8 pb-2 px-1" style={{ width: 'max-content', margin: '0 auto' }}>
+            {CLIENTS.map((client) => (
+              <div
+                key={client.name}
+                title={client.name}
+                className="w-28 h-16 flex-shrink-0 flex items-center justify-center rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-sm transition-all"
+              >
+                <img
+                  src={client.logo}
+                  alt={client.name}
+                  className="w-full h-full object-contain"
+                  draggable={false}
+                />
+              </div>
+            ))}
+          </div>
         </motion.div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- Логотипы выстроены в 1 горизонтальную строку (убрана `flex-wrap`)
- Расстояние между логотипами увеличено с `gap-4` до `gap-8`
- Добавлен горизонтальный скролл с поддержкой ручного перетаскивания мышью (drag-to-scroll)

## Test plan

- [ ] Все логотипы отображаются в одну строку
- [ ] Расстояние между логотипами заметно больше, чем раньше
- [ ] Можно зажать мышь и прокрутить ряд логотипов влево/вправо
- [ ] Курсор меняется на `grab` при наведении и `grabbing` при перетаскивании

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)