### PR TITLE
fix: remove logo card borders to enlarge logos

### DIFF
--- a/src/components/ClientLogos.tsx
+++ b/src/components/ClientLogos.tsx
@@ -111,7 +111,7 @@ export default function ClientLogos() {
                 <div
                   key={`${client.name}-${i}`}
                   title={client.name}
-                  className="w-28 h-16 flex-shrink-0 flex items-center justify-center rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-sm transition-all"
+                  className="w-28 h-16 flex-shrink-0 flex items-center justify-center"
                 >
                   <img
                     src={client.logo}


### PR DESCRIPTION
## Summary

Убраны рамки (border, background, padding, rounded) у карточек логотипов — теперь логотипы занимают всё доступное пространство контейнера и выглядят крупнее.

## Test plan

- [ ] Рамки вокруг логотипов отсутствуют
- [ ] Логотипы выглядят крупнее чем раньше
- [ ] Карусель и стрелки работают как прежде

🤖 Generated with [Claude Code](https://claude.com/claude-code)