### PR TITLE
fix: enlarge BAIR/UpSound logos, add icons to pricing cards

### DIFF
--- a/src/components/ClientLogos.tsx
+++ b/src/components/ClientLogos.tsx
@@ -11,7 +11,7 @@ const CLIENTS = [
   { name: 'ПраВь МСК', logo: '/logos/pravmsk.png' },
   { name: 'Долина Овощей', logo: '/logos/dolina-ovoshchey.png' },
   { name: 'Недорогокупили', logo: '/logos/tyan.png', small: true },
-  { name: 'BAIR', logo: '/logos/bair.jpg', small: true },
+  { name: 'BAIR', logo: '/logos/bair.jpg' },
   { name: 'Milka', logo: '/logos/milka.svg' },
   { name: 'Фонд', logo: '/logos/fyond.png' },
   { name: 'ПМК-178 Бетон', logo: '/logos/pmk178.png' },

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -18,7 +18,10 @@ import {
   FileText,
   BarChart3,
   RefreshCcw,
-  MessageSquare
+  MessageSquare,
+  Rocket,
+  Building2,
+  Wrench
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import ClientLogos from '@/components/ClientLogos'
@@ -707,6 +710,9 @@ export default function Home() {
               <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 px-4 py-1 bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300 text-[10px] font-black uppercase tracking-[0.2em] rounded-full">
                 срок: 2 недели
               </div>
+              <div className="w-12 h-12 rounded-2xl bg-slate-100 dark:bg-slate-800 flex items-center justify-center mb-4">
+                <Rocket size={22} className="text-slate-600 dark:text-slate-300" />
+              </div>
               <h3 className="text-xl font-bold mb-2">Пилотный проект</h3>
               <p className="text-slate-400 dark:text-slate-500 text-sm mb-6">Для проверки на реальной задаче</p>
               <div className="mb-6">
@@ -732,6 +738,9 @@ export default function Home() {
               <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 px-4 py-1 bg-blue-600 text-white text-[10px] font-black uppercase tracking-[0.2em] rounded-full">
                 Популярно
               </div>
+              <div className="w-12 h-12 rounded-2xl bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center mb-4">
+                <Building2 size={22} className="text-blue-600 dark:text-blue-400" />
+              </div>
               <h3 className="text-xl font-bold mb-2">Локальная лицензия</h3>
               <p className="text-slate-400 dark:text-slate-500 text-sm mb-6">В контуре предприятия (год)</p>
               <div className="mb-6 flex items-baseline gap-2">
@@ -752,6 +761,9 @@ export default function Home() {
             </div>
 
             <div className="p-8 rounded-3xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 flex flex-col hover:border-slate-300 dark:hover:border-slate-700 transition-all shadow-sm dark:shadow-none">
+              <div className="w-12 h-12 rounded-2xl bg-slate-100 dark:bg-slate-800 flex items-center justify-center mb-4">
+                <Wrench size={22} className="text-slate-600 dark:text-slate-300" />
+              </div>
               <h3 className="text-xl font-bold mb-2">Разработка</h3>
               <p className="text-slate-400 dark:text-slate-500 text-sm mb-6">Аналитика и настройка</p>
               <div className="mb-6 flex items-baseline gap-2">


### PR DESCRIPTION
## Summary

- **BAIR**: убран `small: true` — логотип теперь на полный размер контейнера
- **UpSound**: уже был на полном размере, без изменений
- **Тарифы**: добавлены иконки к каждой плашке:
  - 🚀 Пилотный проект — `Rocket`
  - 🏢 Локальная лицензия — `Building2` (синий фон, в тон акценту карточки)
  - 🔧 Разработка — `Wrench`

## Test plan

- [ ] BAIR логотип отображается крупнее чем раньше
- [ ] На каждой из 3 карточек тарифов есть иконка над заголовком
- [ ] Иконка «Локальной лицензии» синяя, остальные серые

Closes #98 (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)