### PR TITLE
style: add subtle divider between Problem and For Whom sections

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -208,6 +208,8 @@ export default function Home() {
         </div>
       </section>
 
+      <div className="border-t border-slate-200 dark:border-slate-800" />
+
       {/* 2b. For Whom Section */}
       <section id="for-whom" className="py-24 bg-slate-50 dark:bg-slate-900/50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- Adds a thin `border-t` horizontal rule between the "Своя разработка — это хорошо, но..." (Problem) section and the "Для кого" section
- Uses `border-slate-200 dark:border-slate-800` — same subtle separator token used throughout the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)