### PR TITLE
Добавь иконки на плашки Тарифы на хостинг в облаке, как в секции Как начать быстро и комфортно

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-04-15T15:07:05.209Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-04-15T15:07:05.209Z

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,7 +30,10 @@ import {
   Truck,
   Rocket,
   Building2,
-  Wrench
+  Wrench,
+  Sparkles,
+  Briefcase,
+  ServerCog
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import ClientLogos from '@/components/ClientLogos'
@@ -1020,8 +1023,15 @@ export default function Home() {
           <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
             {/* Free plan */}
             <div className="p-8 rounded-3xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 flex flex-col hover:border-slate-300 dark:hover:border-slate-700 transition-all shadow-sm dark:shadow-none">
-              <h3 className="text-xl font-bold mb-1">Знакомство</h3>
-              <p className="text-slate-400 dark:text-slate-500 text-sm mb-6">Личная песочница</p>
+              <div className="flex items-start gap-4 mb-6">
+                <div className="w-12 h-12 rounded-2xl bg-slate-100 dark:bg-slate-800 flex items-center justify-center flex-shrink-0">
+                  <Sparkles size={22} className="text-slate-600 dark:text-slate-300" />
+                </div>
+                <div>
+                  <h3 className="text-xl font-bold mb-1">Знакомство</h3>
+                  <p className="text-slate-400 dark:text-slate-500 text-sm">Личная песочница</p>
+                </div>
+              </div>
               <div className="mb-6 flex items-baseline gap-2">
                 <span className="text-4xl font-black text-slate-900 dark:text-white">0</span>
                 <span className="text-slate-400 dark:text-slate-500 text-xl font-bold">₽/мес</span>
@@ -1054,8 +1064,15 @@ export default function Home() {
               <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 px-4 py-1 bg-blue-600 text-white text-[10px] font-black uppercase tracking-[0.2em] rounded-full">
                 Популярно
               </div>
-              <h3 className="text-xl font-bold mb-1">Стартап</h3>
-              <p className="text-slate-400 dark:text-slate-500 text-sm mb-6">Подходит для 80% клиентов</p>
+              <div className="flex items-start gap-4 mb-6">
+                <div className="w-12 h-12 rounded-2xl bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center flex-shrink-0">
+                  <Briefcase size={22} className="text-blue-600 dark:text-blue-400" />
+                </div>
+                <div>
+                  <h3 className="text-xl font-bold mb-1">Стартап</h3>
+                  <p className="text-slate-400 dark:text-slate-500 text-sm">Подходит для 80% клиентов</p>
+                </div>
+              </div>
               <div className="mb-2 flex items-baseline gap-2">
                 <span className="text-4xl font-black text-slate-900 dark:text-white">1 950</span>
                 <span className="text-slate-400 dark:text-slate-500 text-xl font-bold">₽/мес</span>
@@ -1085,8 +1102,15 @@ export default function Home() {
 
             {/* Scalable plan */}
             <div className="p-8 rounded-3xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 flex flex-col hover:border-slate-300 dark:hover:border-slate-700 transition-all shadow-sm dark:shadow-none">
-              <h3 className="text-xl font-bold mb-1">Масштабируемый</h3>
-              <p className="text-slate-400 dark:text-slate-500 text-sm mb-6">Регрессивная цена пакетов</p>
+              <div className="flex items-start gap-4 mb-6">
+                <div className="w-12 h-12 rounded-2xl bg-slate-100 dark:bg-slate-800 flex items-center justify-center flex-shrink-0">
+                  <ServerCog size={22} className="text-slate-600 dark:text-slate-300" />
+                </div>
+                <div>
+                  <h3 className="text-xl font-bold mb-1">Масштабируемый</h3>
+                  <p className="text-slate-400 dark:text-slate-500 text-sm">Регрессивная цена пакетов</p>
+                </div>
+              </div>
               <div className="mb-6 flex items-baseline gap-2">
                 <span className="text-4xl font-black text-slate-900 dark:text-white">от 4 900</span>
                 <span className="text-slate-400 dark:text-slate-500 text-xl font-bold">₽/мес</span>


### PR DESCRIPTION
## Что сделано
- добавлены иконки в карточки секции «Тарифы на хостинг в облаке»
- выровнена структура заголовка карточек по образцу секции «Как начать быстро и комфортно»
- сохранены существующие акцентные цвета для популярного тарифа

## Как проверить
- открыть главную страницу
- перейти к секции «Тарифы на хостинг в облаке»
- убедиться, что каждая карточка тарифа имеет иконку слева от заголовка, как в секции «Как начать быстро и комфортно»

## Тесты
- автоматических UI-тестов в репозитории нет
- локальная сборка не выполнена в этой среде, потому что зависимости проекта не установлены и `vite` недоступен

Fixes #104
