### PR TITLE
Add Yandex SmartCaptcha to #cta form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env.local and fill in your credentials.
+
+# Yandex SmartCaptcha client (public) key for the CTA form.
+# Obtain it at https://console.yandex.cloud/ after creating a captcha.
+# Leave empty or omit to disable the captcha widget on the frontend.
+VITE_SMARTCAPTCHA_CLIENT_KEY=ysc1_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-04-20T16:02:17.349Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-04-20T16:02:17.349Z

--- a/experiments/test-issue-108-captcha.php
+++ b/experiments/test-issue-108-captcha.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Test for issue #108: verifyCaptcha behavior for the CTA form.
+ * Same logic as ideav/crm PR #1999.
+ */
+
+define('SMARTCAPTCHA_SERVER_KEY', 'ysc2_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+function verifyCaptcha(string $token): bool {
+    $serverKey = defined('SMARTCAPTCHA_SERVER_KEY') ? SMARTCAPTCHA_SERVER_KEY : '';
+    if ($serverKey === '' || $serverKey === 'ysc2_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') return true;
+    if ($token === '') return false;
+    $url = 'https://smartcaptcha.yandexcloud.net/validate';
+    $params = http_build_query([
+        'secret' => $serverKey,
+        'token'  => $token,
+        'ip'     => $_SERVER['REMOTE_ADDR'] ?? '',
+    ]);
+    $context = stream_context_create([
+        'http' => [
+            'method'  => 'POST',
+            'header'  => "Content-Type: application/x-www-form-urlencoded\r\n",
+            'content' => $params,
+            'timeout' => 5,
+        ],
+    ]);
+    $result = @file_get_contents($url, false, $context);
+    if ($result === false) return false;
+    $res_data = json_decode($result, true);
+    return isset($res_data['status']) && $res_data['status'] === 'ok';
+}
+
+// Test 1: stub key with empty token should return true (captcha skipped)
+$result = verifyCaptcha('');
+assert($result === true, "FAIL: verifyCaptcha('') with stub key should return true (skip captcha)");
+echo "PASS: verifyCaptcha('') with stub key returns true\n";
+
+// Test 2: stub key with any token should return true (captcha skipped)
+$result = verifyCaptcha('some-token');
+assert($result === true, "FAIL: verifyCaptcha('some-token') with stub key should return true (skip captcha)");
+echo "PASS: verifyCaptcha('some-token') with stub key returns true\n";
+
+echo "All tests passed.\n";

--- a/public/telegram-config.example.php
+++ b/public/telegram-config.example.php
@@ -11,7 +11,11 @@
  *   2. Chat ID    — can be a personal chat ID, a group ID, or a channel username.
  *                   To find your chat ID send a message to @userinfobot on Telegram.
  *                   Group/channel IDs are usually negative numbers, e.g. -1001234567890.
+ *   3. SmartCaptcha keys — create a captcha at https://console.yandex.cloud/
+ *                          and copy the client (public) key and server (secret) key.
+ *                          Leave as stubs to disable captcha verification.
  */
 
-define('TELEGRAM_BOT_TOKEN', 'YOUR_BOT_TOKEN_HERE');
-define('TELEGRAM_CHAT_ID',   'YOUR_CHAT_ID_HERE');
+define('TELEGRAM_BOT_TOKEN',        'YOUR_BOT_TOKEN_HERE');
+define('TELEGRAM_CHAT_ID',          'YOUR_CHAT_ID_HERE');
+define('SMARTCAPTCHA_SERVER_KEY',   'ysc2_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');

--- a/public/telegram-notify.php
+++ b/public/telegram-notify.php
@@ -70,6 +70,38 @@ $company = trim($data['company'] ?? '');
 $contact = trim($data['contact'] ?? '');
 $task    = trim($data['task']    ?? '');
 
+// ── SmartCaptcha verification ─────────────────────────────────────────────────
+function verifyCaptcha(string $token): bool {
+    $serverKey = defined('SMARTCAPTCHA_SERVER_KEY') ? SMARTCAPTCHA_SERVER_KEY : '';
+    if ($serverKey === '' || $serverKey === 'ysc2_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') return true;
+    if ($token === '') return false;
+    $url = 'https://smartcaptcha.yandexcloud.net/validate';
+    $params = http_build_query([
+        'secret' => $serverKey,
+        'token'  => $token,
+        'ip'     => $_SERVER['REMOTE_ADDR'] ?? '',
+    ]);
+    $context = stream_context_create([
+        'http' => [
+            'method'  => 'POST',
+            'header'  => "Content-Type: application/x-www-form-urlencoded\r\n",
+            'content' => $params,
+            'timeout' => 5,
+        ],
+    ]);
+    $result = @file_get_contents($url, false, $context);
+    if ($result === false) return false;
+    $res_data = json_decode($result, true);
+    return isset($res_data['status']) && $res_data['status'] === 'ok';
+}
+
+$captchaToken = trim($data['captcha_token'] ?? '');
+if (!verifyCaptcha($captchaToken)) {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'Проверка капчи не пройдена. Попробуйте ещё раз.']);
+    exit;
+}
+
 if ($contact === '' && $task === '') {
     http_response_code(400);
     echo json_encode(['ok' => false, 'error' => 'At least contact or task must be provided.']);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -38,21 +38,82 @@ import {
 import { Link } from 'react-router-dom'
 import ClientLogos from '@/components/ClientLogos'
 
+declare global {
+  interface Window {
+    smartCaptcha?: {
+      getResponse: (widgetId: number) => string
+      reset: (widgetId: number) => void
+      render: (container: HTMLElement | string, params: {
+        sitekey: string
+        callback?: (token: string) => void
+        'error-callback'?: () => void
+        'expired-callback'?: () => void
+      }) => number
+      destroy: (widgetId: number) => void
+    }
+  }
+}
+
 type FormState = 'idle' | 'sending' | 'success' | 'error'
+
+const CAPTCHA_CLIENT_KEY = (import.meta.env.VITE_SMARTCAPTCHA_CLIENT_KEY as string | undefined) ?? ''
 
 export default function Home() {
   const [formState, setFormState] = React.useState<FormState>('idle')
   const [errorMsg, setErrorMsg]   = React.useState('')
   const [consentChecked, setConsentChecked] = React.useState(false)
+  const [captchaToken, setCaptchaToken] = React.useState('')
+  const captchaContainerRef = React.useRef<HTMLDivElement>(null)
+  const captchaWidgetIdRef = React.useRef<number | null>(null)
+
+  React.useEffect(() => {
+    if (!CAPTCHA_CLIENT_KEY) return
+
+    function initCaptcha() {
+      if (!captchaContainerRef.current || !window.smartCaptcha) return
+      captchaWidgetIdRef.current = window.smartCaptcha.render(captchaContainerRef.current, {
+        sitekey: CAPTCHA_CLIENT_KEY,
+        callback: (token: string) => setCaptchaToken(token),
+        'expired-callback': () => setCaptchaToken(''),
+        'error-callback': () => setCaptchaToken(''),
+      })
+    }
+
+    if (window.smartCaptcha) {
+      initCaptcha()
+      return
+    }
+
+    const script = document.createElement('script')
+    script.src = 'https://smartcaptcha.yandexcloud.net/captcha.js'
+    script.defer = true
+    script.onload = initCaptcha
+    document.head.appendChild(script)
+
+    return () => {
+      if (captchaWidgetIdRef.current !== null && window.smartCaptcha) {
+        window.smartCaptcha.destroy(captchaWidgetIdRef.current)
+      }
+    }
+  }, [])
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const form = e.currentTarget
-    const data = {
+    const data: Record<string, string> = {
       name:    (form.elements.namedItem('name')    as HTMLInputElement).value,
       company: (form.elements.namedItem('company') as HTMLInputElement).value,
       contact: (form.elements.namedItem('contact') as HTMLInputElement).value,
       task:    (form.elements.namedItem('task')    as HTMLTextAreaElement).value,
+    }
+
+    if (CAPTCHA_CLIENT_KEY) {
+      if (!captchaToken) {
+        setErrorMsg('Пожалуйста, пройдите проверку капчи.')
+        setFormState('error')
+        return
+      }
+      data.captcha_token = captchaToken
     }
 
     setFormState('sending')
@@ -68,9 +129,17 @@ export default function Home() {
       if (json.ok) {
         setFormState('success')
         form.reset()
+        setCaptchaToken('')
+        if (captchaWidgetIdRef.current !== null && window.smartCaptcha) {
+          window.smartCaptcha.reset(captchaWidgetIdRef.current)
+        }
       } else {
         setFormState('error')
         setErrorMsg(json.error ?? 'Произошла ошибка. Попробуйте позже.')
+        if (captchaWidgetIdRef.current !== null && window.smartCaptcha) {
+          window.smartCaptcha.reset(captchaWidgetIdRef.current)
+          setCaptchaToken('')
+        }
       }
     } catch {
       setFormState('error')
@@ -968,6 +1037,10 @@ export default function Home() {
                 )}
                 {formState === 'error' && (
                   <div className="text-red-500 dark:text-red-400 text-sm font-medium">{errorMsg}</div>
+                )}
+
+                {CAPTCHA_CLIENT_KEY && (
+                  <div ref={captchaContainerRef} />
                 )}
 
                 <label className="flex items-start gap-3 cursor-pointer">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SMARTCAPTCHA_CLIENT_KEY?: string
+  readonly BASE_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Problem

The #cta contact form had no bot protection. Issue #108 requested adding Yandex SmartCaptcha with the same keys and logic as [ideav/crm#1999](https://github.com/ideav/crm/pull/1999).

## Solution

### Frontend (`src/pages/Home.tsx`)
- Reads `VITE_SMARTCAPTCHA_CLIENT_KEY` from environment variables
- Dynamically loads `smartcaptcha.yandexcloud.net/captcha.js` and renders the widget inside the form
- Sends the captcha token as `captcha_token` with the form POST
- Resets the widget after successful submission or server error

### Backend (`public/telegram-notify.php`)
- Verifies the captcha token against Yandex SmartCaptcha API before processing the form
- Returns HTTP 400 if verification fails
- Skips verification when `SMARTCAPTCHA_SERVER_KEY` is empty or the placeholder stub `ysc2_XXX...` (same logic as ideav/crm#1999)

### Config & Docs
- `public/telegram-config.example.php` — added `SMARTCAPTCHA_SERVER_KEY`
- `.env.example` — documents `VITE_SMARTCAPTCHA_CLIENT_KEY`
- `src/vite-env.d.ts` — added Vite env type declarations (fixes pre-existing `import.meta.env` TS errors)

## How to enable captcha

1. Create a captcha at https://console.yandex.cloud/
2. Copy the **client (public) key** → add `VITE_SMARTCAPTCHA_CLIENT_KEY=ysc1_...` to `.env.local`
3. Copy the **server (secret) key** → add `define('SMARTCAPTCHA_SERVER_KEY', 'ysc2_...')` to `public/telegram-config.php`

Leaving `VITE_SMARTCAPTCHA_CLIENT_KEY` empty (or unset) hides the widget and skips server-side validation — useful for local dev.

## Test

`experiments/test-issue-108-captcha.php` — verifies that `verifyCaptcha()` returns `true` with the stub key regardless of token:

```
PASS: verifyCaptcha('') with stub key returns true
PASS: verifyCaptcha('some-token') with stub key returns true
All tests passed.
```

Fixes #108