### PR TITLE
Enable Yandex SmartCaptcha with client key

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Yandex SmartCaptcha client (public) key for the CTA form.
+VITE_SMARTCAPTCHA_CLIENT_KEY=ysc1_2EhhILbwBUoENgVrsbujEEPhih5dgPfh4Rs2WfImcd89ae95

--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@
 # Yandex SmartCaptcha client (public) key for the CTA form.
 # Obtain it at https://console.yandex.cloud/ after creating a captcha.
 # Leave empty or omit to disable the captcha widget on the frontend.
-VITE_SMARTCAPTCHA_CLIENT_KEY=ysc1_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+VITE_SMARTCAPTCHA_CLIENT_KEY=ysc1_2EhhILbwBUoENgVrsbujEEPhih5dgPfh4Rs2WfImcd89ae95

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-04-23T05:48:25.534Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-04-23T05:48:25.534Z


### PR DESCRIPTION
## Problem

Issue #110 requested enabling the captcha on the #cta form and setting the new client key.

The SmartCaptcha integration was already wired up in #109. The captcha widget is shown when `VITE_SMARTCAPTCHA_CLIENT_KEY` is set, and hidden when it is empty.

## Solution

- Created `.env` with `VITE_SMARTCAPTCHA_CLIENT_KEY=ysc1_2EhhILbwBUoENgVrsbujEEPhih5dgPfh4Rs2WfImcd89ae95` so the captcha widget is enabled in production builds.
- Updated `.env.example` to reflect the actual key (the client/public key is not a secret — it is safe to commit).

## Verification

Build output confirms the key is embedded:

```
grep ysc1_ dist/assets/index-*.js
ysc1_2EhhILbwBUoENgVrsbujEEPhih5dgPfh4Rs2WfImcd89ae95
```

Tests still pass: `npm test` → 1 pass, 0 fail.

Fixes #110