### PR TITLE
Fix deterministic theme initial render

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-04-24T10:14:40.081Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-04-24T10:14:40.081Z

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -13,11 +13,14 @@ const ThemeContext = createContext<ThemeContextValue>({
 })
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  useEffect(() => {
     const stored = localStorage.getItem('theme')
-    if (stored === 'light' || stored === 'dark') return stored
-    return 'light'
-  })
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored)
+    }
+  }, [])
 
   useEffect(() => {
     const root = document.documentElement

--- a/tests/theme-initial-render.test.mjs
+++ b/tests/theme-initial-render.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const themeSource = readFileSync(new URL('../src/context/ThemeContext.tsx', import.meta.url), 'utf8')
+
+test('theme provider keeps the initial render independent from localStorage', () => {
+  assert.match(
+    themeSource,
+    /useState<Theme>\('light'\)/,
+    'Initial theme state should be deterministic for hydration.',
+  )
+  assert.doesNotMatch(
+    themeSource,
+    /useState<Theme>\(\(\) =>[\s\S]*localStorage\.getItem/,
+    'Do not read browser storage inside the initial state function.',
+  )
+  assert.match(
+    themeSource,
+    /useEffect\(\(\) => \{[\s\S]*localStorage\.getItem\('theme'\)[\s\S]*setTheme\(stored\)[\s\S]*\}, \[\]\)/,
+    'Stored theme should be applied after the first client render.',
+  )
+})


### PR DESCRIPTION
## Summary
- Make the root theme state deterministic on the first render by defaulting to light.
- Apply the saved localStorage theme after mount instead of during the initial state initializer.
- Add a regression test that prevents localStorage reads from returning to the initial render path.

## Reproduction
The reported React minified errors #418 and #423 are hydration mismatch/recovery errors. The root app could render different markup on the first client render depending on localStorage theme state, because ThemeProvider read localStorage inside the useState initializer.

## Verification
- npm test
- npm run build

Fixes #112