### PR TITLE
Add 5 abstract automation SVG banners for Yandex Direct (#116)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-04-25T16:47:48.918Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-04-25T16:47:48.918Z

--- a/public/ad-images/ad-1-neural-flow.svg
+++ b/public/ad-images/ad-1-neural-flow.svg
@@ -1,0 +1,171 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="628" viewBox="0 0 1200 628">
+  <defs>
+    <linearGradient id="bg1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a0a1a"/>
+      <stop offset="100%" stop-color="#0d1b3e"/>
+    </linearGradient>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+    <radialGradient id="glow1" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#6366f1" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#6366f1" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glow2" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#06b6d4" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="blur1">
+      <feGaussianBlur stdDeviation="18"/>
+    </filter>
+    <filter id="blur2">
+      <feGaussianBlur stdDeviation="8"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="628" fill="url(#bg1)"/>
+
+  <!-- Glow blobs -->
+  <ellipse cx="320" cy="280" rx="260" ry="200" fill="url(#glow1)" filter="url(#blur1)"/>
+  <ellipse cx="880" cy="350" rx="220" ry="180" fill="url(#glow2)" filter="url(#blur1)"/>
+
+  <!-- Grid lines -->
+  <g stroke="#1e2a4a" stroke-width="1" opacity="0.5">
+    <line x1="0" y1="100" x2="1200" y2="100"/>
+    <line x1="0" y1="200" x2="1200" y2="200"/>
+    <line x1="0" y1="300" x2="1200" y2="300"/>
+    <line x1="0" y1="400" x2="1200" y2="400"/>
+    <line x1="0" y1="500" x2="1200" y2="500"/>
+    <line x1="150" y1="0" x2="150" y2="628"/>
+    <line x1="300" y1="0" x2="300" y2="628"/>
+    <line x1="450" y1="0" x2="450" y2="628"/>
+    <line x1="600" y1="0" x2="600" y2="628"/>
+    <line x1="750" y1="0" x2="750" y2="628"/>
+    <line x1="900" y1="0" x2="900" y2="628"/>
+    <line x1="1050" y1="0" x2="1050" y2="628"/>
+  </g>
+
+  <!-- Neural network nodes and connections -->
+  <!-- Layer 1 -->
+  <circle cx="120" cy="160" r="10" fill="#6366f1" opacity="0.9"/>
+  <circle cx="120" cy="314" r="10" fill="#6366f1" opacity="0.9"/>
+  <circle cx="120" cy="468" r="10" fill="#6366f1" opacity="0.9"/>
+
+  <!-- Layer 2 -->
+  <circle cx="320" cy="120" r="10" fill="#7c3aed" opacity="0.9"/>
+  <circle cx="320" cy="240" r="10" fill="#7c3aed" opacity="0.9"/>
+  <circle cx="320" cy="360" r="10" fill="#7c3aed" opacity="0.9"/>
+  <circle cx="320" cy="480" r="10" fill="#7c3aed" opacity="0.9"/>
+
+  <!-- Layer 3 -->
+  <circle cx="520" cy="180" r="14" fill="#06b6d4" opacity="0.95"/>
+  <circle cx="520" cy="314" r="14" fill="#06b6d4" opacity="0.95"/>
+  <circle cx="520" cy="448" r="14" fill="#06b6d4" opacity="0.95"/>
+
+  <!-- Layer 4 -->
+  <circle cx="720" cy="120" r="10" fill="#7c3aed" opacity="0.9"/>
+  <circle cx="720" cy="240" r="10" fill="#7c3aed" opacity="0.9"/>
+  <circle cx="720" cy="360" r="10" fill="#7c3aed" opacity="0.9"/>
+  <circle cx="720" cy="480" r="10" fill="#7c3aed" opacity="0.9"/>
+
+  <!-- Layer 5 output -->
+  <circle cx="920" cy="200" r="12" fill="#6366f1" opacity="0.9"/>
+  <circle cx="920" cy="314" r="12" fill="#6366f1" opacity="0.9"/>
+  <circle cx="920" cy="428" r="12" fill="#6366f1" opacity="0.9"/>
+
+  <!-- Connections L1->L2 -->
+  <g stroke="#6366f1" stroke-width="0.8" opacity="0.25">
+    <line x1="120" y1="160" x2="320" y2="120"/>
+    <line x1="120" y1="160" x2="320" y2="240"/>
+    <line x1="120" y1="160" x2="320" y2="360"/>
+    <line x1="120" y1="160" x2="320" y2="480"/>
+    <line x1="120" y1="314" x2="320" y2="120"/>
+    <line x1="120" y1="314" x2="320" y2="240"/>
+    <line x1="120" y1="314" x2="320" y2="360"/>
+    <line x1="120" y1="314" x2="320" y2="480"/>
+    <line x1="120" y1="468" x2="320" y2="120"/>
+    <line x1="120" y1="468" x2="320" y2="240"/>
+    <line x1="120" y1="468" x2="320" y2="360"/>
+    <line x1="120" y1="468" x2="320" y2="480"/>
+  </g>
+
+  <!-- Connections L2->L3 -->
+  <g stroke="#8b5cf6" stroke-width="1" opacity="0.3">
+    <line x1="320" y1="120" x2="520" y2="180"/>
+    <line x1="320" y1="120" x2="520" y2="314"/>
+    <line x1="320" y1="120" x2="520" y2="448"/>
+    <line x1="320" y1="240" x2="520" y2="180"/>
+    <line x1="320" y1="240" x2="520" y2="314"/>
+    <line x1="320" y1="240" x2="520" y2="448"/>
+    <line x1="320" y1="360" x2="520" y2="180"/>
+    <line x1="320" y1="360" x2="520" y2="314"/>
+    <line x1="320" y1="360" x2="520" y2="448"/>
+    <line x1="320" y1="480" x2="520" y2="180"/>
+    <line x1="320" y1="480" x2="520" y2="314"/>
+    <line x1="320" y1="480" x2="520" y2="448"/>
+  </g>
+
+  <!-- Connections L3->L4 -->
+  <g stroke="#06b6d4" stroke-width="1" opacity="0.3">
+    <line x1="520" y1="180" x2="720" y2="120"/>
+    <line x1="520" y1="180" x2="720" y2="240"/>
+    <line x1="520" y1="180" x2="720" y2="360"/>
+    <line x1="520" y1="180" x2="720" y2="480"/>
+    <line x1="520" y1="314" x2="720" y2="120"/>
+    <line x1="520" y1="314" x2="720" y2="240"/>
+    <line x1="520" y1="314" x2="720" y2="360"/>
+    <line x1="520" y1="314" x2="720" y2="480"/>
+    <line x1="520" y1="448" x2="720" y2="120"/>
+    <line x1="520" y1="448" x2="720" y2="240"/>
+    <line x1="520" y1="448" x2="720" y2="360"/>
+    <line x1="520" y1="448" x2="720" y2="480"/>
+  </g>
+
+  <!-- Connections L4->L5 -->
+  <g stroke="#6366f1" stroke-width="0.8" opacity="0.25">
+    <line x1="720" y1="120" x2="920" y2="200"/>
+    <line x1="720" y1="120" x2="920" y2="314"/>
+    <line x1="720" y1="120" x2="920" y2="428"/>
+    <line x1="720" y1="240" x2="920" y2="200"/>
+    <line x1="720" y1="240" x2="920" y2="314"/>
+    <line x1="720" y1="240" x2="920" y2="428"/>
+    <line x1="720" y1="360" x2="920" y2="200"/>
+    <line x1="720" y1="360" x2="920" y2="314"/>
+    <line x1="720" y1="360" x2="920" y2="428"/>
+    <line x1="720" y1="480" x2="920" y2="200"/>
+    <line x1="720" y1="480" x2="920" y2="314"/>
+    <line x1="720" y1="480" x2="920" y2="428"/>
+  </g>
+
+  <!-- Active signal paths (bright) -->
+  <line x1="120" y1="314" x2="320" y2="240" stroke="url(#accentGrad)" stroke-width="2" opacity="0.8"/>
+  <line x1="320" y1="240" x2="520" y2="314" stroke="url(#accentGrad)" stroke-width="2.5" opacity="0.9"/>
+  <line x1="520" y1="314" x2="720" y2="360" stroke="url(#accentGrad)" stroke-width="2.5" opacity="0.9"/>
+  <line x1="720" y1="360" x2="920" y2="314" stroke="url(#accentGrad)" stroke-width="2" opacity="0.8"/>
+
+  <!-- Highlighted nodes -->
+  <circle cx="120" cy="314" r="10" fill="#6366f1"/>
+  <circle cx="120" cy="314" r="18" fill="#6366f1" opacity="0.2" filter="url(#blur2)"/>
+  <circle cx="520" cy="314" r="14" fill="#06b6d4"/>
+  <circle cx="520" cy="314" r="26" fill="#06b6d4" opacity="0.25" filter="url(#blur2)"/>
+  <circle cx="920" cy="314" r="12" fill="#6366f1"/>
+  <circle cx="920" cy="314" r="22" fill="#6366f1" opacity="0.2" filter="url(#blur2)"/>
+
+  <!-- Right side output arrow -->
+  <g transform="translate(960, 290)">
+    <rect x="0" y="0" width="180" height="48" rx="24" fill="url(#accentGrad)" opacity="0.15"/>
+    <rect x="0" y="0" width="180" height="48" rx="24" fill="none" stroke="url(#accentGrad)" stroke-width="1.5"/>
+    <text x="90" y="30" font-family="'Arial', sans-serif" font-size="15" fill="#e2e8f0" text-anchor="middle" font-weight="600" letter-spacing="1">АВТОМАТИЗАЦИЯ</text>
+  </g>
+
+  <!-- Main headline -->
+  <text x="600" y="58" font-family="'Arial', sans-serif" font-size="13" fill="#6366f1" text-anchor="middle" letter-spacing="4" font-weight="700">НЕЙРОННАЯ СЕТЬ</text>
+
+  <!-- Bottom text -->
+  <rect x="0" y="570" width="1200" height="58" fill="#070711" opacity="0.7"/>
+  <text x="60" y="603" font-family="'Arial', sans-serif" font-size="28" fill="white" font-weight="700">Backlogram</text>
+  <text x="60" y="622" font-family="'Arial', sans-serif" font-size="11" fill="#94a3b8" letter-spacing="2">АВТОМАТИЗАЦИЯ БИЗНЕС-ПРОЦЕССОВ</text>
+  <text x="1140" y="610" font-family="'Arial', sans-serif" font-size="12" fill="#6366f1" text-anchor="end" letter-spacing="1">backlogram.ru</text>
+</svg>

--- a/public/ad-images/ad-2-data-circuit.svg
+++ b/public/ad-images/ad-2-data-circuit.svg
@@ -1,0 +1,153 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="628" viewBox="0 0 1200 628">
+  <defs>
+    <linearGradient id="bg2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#050d1a"/>
+      <stop offset="100%" stop-color="#071428"/>
+    </linearGradient>
+    <linearGradient id="cyanGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="purpleGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+    <radialGradient id="centerGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#06b6d4" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="gf">
+      <feGaussianBlur stdDeviation="20"/>
+    </filter>
+    <filter id="gf2">
+      <feGaussianBlur stdDeviation="6"/>
+    </filter>
+    <clipPath id="clip1">
+      <rect width="1200" height="628"/>
+    </clipPath>
+  </defs>
+
+  <rect width="1200" height="628" fill="url(#bg2)"/>
+
+  <!-- Background glow -->
+  <ellipse cx="600" cy="314" rx="350" ry="280" fill="url(#centerGlow)" filter="url(#gf)"/>
+
+  <!-- Circuit board pattern -->
+  <!-- Horizontal traces -->
+  <g stroke="#0e2a4a" stroke-width="1.5" fill="none" clip-path="url(#clip1)">
+    <polyline points="0,80 200,80 200,140 400,140 400,80 700,80 700,200 900,200 900,80 1200,80"/>
+    <polyline points="0,200 100,200 100,260 300,260 300,180 500,180 500,260 650,260 650,180 800,180 800,260 1000,260 1000,200 1200,200"/>
+    <polyline points="0,340 150,340 150,400 350,400 350,320 550,320 550,400 700,400 700,320 850,320 850,400 1050,400 1050,340 1200,340"/>
+    <polyline points="0,470 200,470 200,530 400,530 400,470 600,470 600,530 800,530 800,470 1000,470 1000,530 1200,530"/>
+    <polyline points="0,580 1200,580"/>
+  </g>
+
+  <!-- Vertical connections -->
+  <g stroke="#0e2a4a" stroke-width="1.5" fill="none">
+    <line x1="200" y1="80" x2="200" y2="200"/>
+    <line x1="400" y1="140" x2="400" y2="260"/>
+    <line x1="600" y1="180" x2="600" y2="320"/>
+    <line x1="800" y1="200" x2="800" y2="340"/>
+    <line x1="1000" y1="260" x2="1000" y2="400"/>
+    <line x1="300" y1="260" x2="300" y2="400"/>
+    <line x1="550" y1="260" x2="550" y2="400"/>
+    <line x1="700" y1="320" x2="700" y2="470"/>
+    <line x1="400" y1="400" x2="400" y2="470"/>
+    <line x1="800" y1="400" x2="800" y2="470"/>
+  </g>
+
+  <!-- Active circuit traces (glowing) -->
+  <g fill="none">
+    <polyline points="100,314 100,260 300,260 300,180 500,180 500,260 700,260 700,314"
+      stroke="#06b6d4" stroke-width="2.5" opacity="0.9"/>
+    <polyline points="700,314 700,400 900,400 900,314 1100,314"
+      stroke="#3b82f6" stroke-width="2.5" opacity="0.9"/>
+    <polyline points="100,314 100,400 300,400 300,314"
+      stroke="#8b5cf6" stroke-width="2" opacity="0.8"/>
+  </g>
+  <!-- Glow duplicates -->
+  <g fill="none" filter="url(#gf2)">
+    <polyline points="100,314 100,260 300,260 300,180 500,180 500,260 700,260 700,314"
+      stroke="#06b6d4" stroke-width="4" opacity="0.4"/>
+    <polyline points="700,314 700,400 900,400 900,314 1100,314"
+      stroke="#3b82f6" stroke-width="4" opacity="0.4"/>
+  </g>
+
+  <!-- Circuit nodes/pads -->
+  <g>
+    <!-- Dim nodes -->
+    <circle cx="200" cy="80" r="5" fill="#0e2a4a" stroke="#1e3a6a" stroke-width="1.5"/>
+    <circle cx="400" cy="140" r="5" fill="#0e2a4a" stroke="#1e3a6a" stroke-width="1.5"/>
+    <circle cx="700" cy="80" r="5" fill="#0e2a4a" stroke="#1e3a6a" stroke-width="1.5"/>
+    <circle cx="900" cy="200" r="5" fill="#0e2a4a" stroke="#1e3a6a" stroke-width="1.5"/>
+    <circle cx="300" cy="400" r="5" fill="#0e2a4a" stroke="#1e3a6a" stroke-width="1.5"/>
+    <circle cx="1000" cy="400" r="5" fill="#0e2a4a" stroke="#1e3a6a" stroke-width="1.5"/>
+
+    <!-- Active nodes -->
+    <circle cx="100" cy="314" r="8" fill="#06b6d4"/>
+    <circle cx="100" cy="314" r="16" fill="#06b6d4" opacity="0.2" filter="url(#gf2)"/>
+    <circle cx="300" cy="260" r="7" fill="#06b6d4" opacity="0.9"/>
+    <circle cx="500" cy="180" r="7" fill="#06b6d4" opacity="0.9"/>
+    <circle cx="700" cy="260" r="7" fill="#06b6d4" opacity="0.9"/>
+    <circle cx="700" cy="314" r="10" fill="#3b82f6"/>
+    <circle cx="700" cy="314" r="20" fill="#3b82f6" opacity="0.2" filter="url(#gf2)"/>
+    <circle cx="900" cy="400" r="7" fill="#3b82f6" opacity="0.9"/>
+    <circle cx="1100" cy="314" r="8" fill="#3b82f6"/>
+    <circle cx="1100" cy="314" r="16" fill="#3b82f6" opacity="0.2" filter="url(#gf2)"/>
+    <circle cx="300" cy="314" r="7" fill="#8b5cf6" opacity="0.9"/>
+    <circle cx="100" cy="400" r="6" fill="#8b5cf6" opacity="0.8"/>
+  </g>
+
+  <!-- IC Chip in center -->
+  <rect x="480" y="234" width="240" height="160" rx="8" fill="#060e1f" stroke="#06b6d4" stroke-width="1.5"/>
+  <!-- Chip pins left -->
+  <g stroke="#06b6d4" stroke-width="2">
+    <line x1="460" y1="254" x2="480" y2="254"/>
+    <line x1="460" y1="274" x2="480" y2="274"/>
+    <line x1="460" y1="294" x2="480" y2="294"/>
+    <line x1="460" y1="314" x2="480" y2="314"/>
+    <line x1="460" y1="334" x2="480" y2="334"/>
+    <line x1="460" y1="354" x2="480" y2="354"/>
+    <line x1="460" y1="374" x2="480" y2="374"/>
+  </g>
+  <!-- Chip pins right -->
+  <g stroke="#3b82f6" stroke-width="2">
+    <line x1="720" y1="254" x2="740" y2="254"/>
+    <line x1="720" y1="274" x2="740" y2="274"/>
+    <line x1="720" y1="294" x2="740" y2="294"/>
+    <line x1="720" y1="314" x2="740" y2="314"/>
+    <line x1="720" y1="334" x2="740" y2="334"/>
+    <line x1="720" y1="354" x2="740" y2="354"/>
+    <line x1="720" y1="374" x2="740" y2="374"/>
+  </g>
+  <!-- Chip pins top -->
+  <g stroke="#8b5cf6" stroke-width="2">
+    <line x1="510" y1="214" x2="510" y2="234"/>
+    <line x1="540" y1="214" x2="540" y2="234"/>
+    <line x1="570" y1="214" x2="570" y2="234"/>
+    <line x1="600" y1="214" x2="600" y2="234"/>
+    <line x1="630" y1="214" x2="630" y2="234"/>
+    <line x1="660" y1="214" x2="660" y2="234"/>
+    <line x1="690" y1="214" x2="690" y2="234"/>
+  </g>
+  <!-- Chip pins bottom -->
+  <g stroke="#8b5cf6" stroke-width="2">
+    <line x1="510" y1="394" x2="510" y2="414"/>
+    <line x1="540" y1="394" x2="540" y2="414"/>
+    <line x1="570" y1="394" x2="570" y2="414"/>
+    <line x1="600" y1="394" x2="600" y2="414"/>
+    <line x1="630" y1="394" x2="630" y2="414"/>
+    <line x1="660" y1="394" x2="660" y2="414"/>
+    <line x1="690" y1="394" x2="690" y2="414"/>
+  </g>
+  <!-- Chip label -->
+  <text x="600" y="304" font-family="'Courier New', monospace" font-size="13" fill="#06b6d4" text-anchor="middle" font-weight="700" letter-spacing="2">AUTO</text>
+  <text x="600" y="324" font-family="'Courier New', monospace" font-size="13" fill="#06b6d4" text-anchor="middle" font-weight="700" letter-spacing="2">CORE</text>
+  <text x="600" y="345" font-family="'Courier New', monospace" font-size="9" fill="#3b82f6" text-anchor="middle" letter-spacing="1">v2.0</text>
+
+  <!-- Bottom bar -->
+  <rect x="0" y="570" width="1200" height="58" fill="#020810" opacity="0.85"/>
+  <text x="60" y="603" font-family="'Arial', sans-serif" font-size="28" fill="white" font-weight="700">Backlogram</text>
+  <text x="60" y="622" font-family="'Arial', sans-serif" font-size="11" fill="#94a3b8" letter-spacing="2">УМНАЯ АВТОМАТИЗАЦИЯ ДЛЯ ВАШЕГО БИЗНЕСА</text>
+  <text x="1140" y="610" font-family="'Arial', sans-serif" font-size="12" fill="#06b6d4" text-anchor="end" letter-spacing="1">backlogram.ru</text>
+</svg>

--- a/public/ad-images/ad-3-infinity-loop.svg
+++ b/public/ad-images/ad-3-infinity-loop.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="628" viewBox="0 0 1200 628">
+  <defs>
+    <linearGradient id="bg3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#050008"/>
+      <stop offset="50%" stop-color="#0d0520"/>
+      <stop offset="100%" stop-color="#050008"/>
+    </linearGradient>
+    <linearGradient id="loopGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#a855f7"/>
+      <stop offset="50%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+    <linearGradient id="loopGrad2" x1="100%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#f472b6"/>
+      <stop offset="100%" stop-color="#8b5cf6"/>
+    </linearGradient>
+    <radialGradient id="leftGlow" cx="36%" cy="50%" r="28%">
+      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="rightGlow" cx="64%" cy="50%" r="28%">
+      <stop offset="0%" stop-color="#06b6d4" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="blurLoop">
+      <feGaussianBlur stdDeviation="22"/>
+    </filter>
+    <filter id="blurLoopSm">
+      <feGaussianBlur stdDeviation="7"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="628" fill="url(#bg3)"/>
+
+  <!-- Glow -->
+  <ellipse cx="432" cy="314" rx="220" ry="200" fill="url(#leftGlow)" filter="url(#blurLoop)"/>
+  <ellipse cx="768" cy="314" rx="220" ry="200" fill="url(#rightGlow)" filter="url(#blurLoop)"/>
+
+  <!-- Particle dots -->
+  <g fill="#a855f7" opacity="0.6">
+    <circle cx="80" cy="100" r="2"/>
+    <circle cx="200" cy="60" r="1.5"/>
+    <circle cx="350" cy="130" r="2"/>
+    <circle cx="150" cy="200" r="1.5"/>
+    <circle cx="50" cy="300" r="2"/>
+    <circle cx="100" cy="450" r="1.5"/>
+    <circle cx="280" cy="520" r="2"/>
+    <circle cx="420" cy="560" r="1.5"/>
+  </g>
+  <g fill="#06b6d4" opacity="0.5">
+    <circle cx="1120" cy="100" r="2"/>
+    <circle cx="1000" cy="60" r="1.5"/>
+    <circle cx="850" cy="130" r="2"/>
+    <circle cx="1050" cy="200" r="1.5"/>
+    <circle cx="1150" cy="300" r="2"/>
+    <circle cx="1100" cy="450" r="1.5"/>
+    <circle cx="920" cy="520" r="2"/>
+    <circle cx="780" cy="560" r="1.5"/>
+  </g>
+
+  <!-- Infinity symbol - outer glow -->
+  <!-- Left lobe outer glow -->
+  <ellipse cx="432" cy="314" rx="190" ry="140" fill="none" stroke="#8b5cf6" stroke-width="8" opacity="0.12" filter="url(#blurLoopSm)"/>
+  <!-- Right lobe outer glow -->
+  <ellipse cx="768" cy="314" rx="190" ry="140" fill="none" stroke="#06b6d4" stroke-width="8" opacity="0.12" filter="url(#blurLoopSm)"/>
+
+  <!-- Infinity loop path (approximate with ellipses and crossing) -->
+  <!-- Left lobe -->
+  <ellipse cx="432" cy="314" rx="190" ry="140" fill="none" stroke="url(#loopGrad2)" stroke-width="4" opacity="0.9"/>
+  <!-- Right lobe -->
+  <ellipse cx="768" cy="314" rx="190" ry="140" fill="none" stroke="url(#loopGrad)" stroke-width="4" opacity="0.9"/>
+
+  <!-- Crossover mask (white rectangle to hide middle) -->
+  <rect x="568" y="240" width="64" height="148" fill="#0d0520"/>
+
+  <!-- Re-draw crossing parts on top -->
+  <!-- Left-to-right crossing stroke top -->
+  <path d="M 568,250 Q 600,314 632,250" fill="none" stroke="#a855f7" stroke-width="4" opacity="0.9"/>
+  <!-- Left-to-right crossing stroke bottom -->
+  <path d="M 568,378 Q 600,314 632,378" fill="none" stroke="#06b6d4" stroke-width="4" opacity="0.9"/>
+
+  <!-- Moving data points on loop -->
+  <circle cx="432" cy="174" r="8" fill="#a855f7">
+    <animate attributeName="cx" values="432;568;600;632;768;632;600;568;432" dur="5s" repeatCount="indefinite" calcMode="spline" keySplines="0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1"/>
+    <animate attributeName="cy" values="174;280;314;280;174;280;314;280;174" dur="5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="768" cy="454" r="8" fill="#06b6d4">
+    <animate attributeName="cx" values="768;632;600;568;432;568;600;632;768" dur="5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="454;348;314;348;454;348;314;348;454" dur="5s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Labels on loop -->
+  <text x="310" y="240" font-family="'Arial', sans-serif" font-size="12" fill="#c084fc" text-anchor="middle" letter-spacing="2" font-weight="600">ДАННЫЕ</text>
+  <text x="560" y="190" font-family="'Arial', sans-serif" font-size="12" fill="#e2e8f0" text-anchor="middle" letter-spacing="2">АНАЛИЗ</text>
+  <text x="890" y="240" font-family="'Arial', sans-serif" font-size="12" fill="#67e8f9" text-anchor="middle" letter-spacing="2" font-weight="600">РЕШЕНИЕ</text>
+  <text x="890" y="420" font-family="'Arial', sans-serif" font-size="12" fill="#67e8f9" text-anchor="middle" letter-spacing="2">ДЕЙСТВИЕ</text>
+  <text x="310" y="420" font-family="'Arial', sans-serif" font-size="12" fill="#c084fc" text-anchor="middle" letter-spacing="2">РЕЗУЛЬТАТ</text>
+
+  <!-- Center logo mark -->
+  <circle cx="600" cy="314" r="24" fill="#0d0520" stroke="url(#loopGrad)" stroke-width="2"/>
+  <text x="600" y="320" font-family="'Arial', sans-serif" font-size="14" fill="white" text-anchor="middle" font-weight="700">∞</text>
+
+  <!-- Right side headline block -->
+  <rect x="1000" y="180" width="160" height="100" rx="6" fill="#0d0520" stroke="#6366f1" stroke-width="1" opacity="0.8"/>
+  <text x="1080" y="218" font-family="'Arial', sans-serif" font-size="13" fill="#c084fc" text-anchor="middle" font-weight="700" letter-spacing="1">ЗАМКНУТЫЙ</text>
+  <text x="1080" y="238" font-family="'Arial', sans-serif" font-size="13" fill="#c084fc" text-anchor="middle" font-weight="700" letter-spacing="1">ЦИКЛ</text>
+  <text x="1080" y="262" font-family="'Arial', sans-serif" font-size="10" fill="#94a3b8" text-anchor="middle" letter-spacing="1">АВТОМАТИЗАЦИИ</text>
+
+  <!-- Bottom bar -->
+  <rect x="0" y="570" width="1200" height="58" fill="#050008" opacity="0.9"/>
+  <text x="60" y="603" font-family="'Arial', sans-serif" font-size="28" fill="white" font-weight="700">Backlogram</text>
+  <text x="60" y="622" font-family="'Arial', sans-serif" font-size="11" fill="#94a3b8" letter-spacing="2">АВТОМАТИЗИРУЕМ — ВЫ РАСТЁТЕ</text>
+  <text x="1140" y="610" font-family="'Arial', sans-serif" font-size="12" fill="#a855f7" text-anchor="end" letter-spacing="1">backlogram.ru</text>
+</svg>

--- a/public/ad-images/ad-4-gear-flow.svg
+++ b/public/ad-images/ad-4-gear-flow.svg
@@ -1,0 +1,176 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="628" viewBox="0 0 1200 628">
+  <defs>
+    <linearGradient id="bg4" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#020c18"/>
+      <stop offset="100%" stop-color="#081428"/>
+    </linearGradient>
+    <linearGradient id="emeraldGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#10b981"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+    <linearGradient id="amberGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#ef4444"/>
+    </linearGradient>
+    <linearGradient id="blueGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+    <radialGradient id="glowGear" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#10b981" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#10b981" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="gearBlur">
+      <feGaussianBlur stdDeviation="15"/>
+    </filter>
+    <filter id="gearBlurSm">
+      <feGaussianBlur stdDeviation="5"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="628" fill="url(#bg4)"/>
+
+  <!-- Background glow spots -->
+  <ellipse cx="350" cy="300" rx="200" ry="180" fill="#10b981" opacity="0.08" filter="url(#gearBlur)"/>
+  <ellipse cx="750" cy="300" rx="180" ry="160" fill="#3b82f6" opacity="0.1" filter="url(#gearBlur)"/>
+  <ellipse cx="1050" cy="300" rx="140" ry="120" fill="#f59e0b" opacity="0.08" filter="url(#gearBlur)"/>
+
+  <!-- Gear 1 (large, left) - 12 teeth -->
+  <g transform="translate(320, 280)">
+    <circle r="95" fill="#040e1c" stroke="#10b981" stroke-width="2"/>
+    <circle r="68" fill="#040e1c" stroke="#10b981" stroke-width="1.5"/>
+    <circle r="22" fill="#10b981" opacity="0.3"/>
+    <circle r="12" fill="#10b981"/>
+    <!-- Gear teeth (12) -->
+    <g fill="#040e1c" stroke="#10b981" stroke-width="1.5">
+      <rect x="-10" y="-108" width="20" height="22" rx="3"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(30)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(60)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(90)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(120)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(150)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(180)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(210)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(240)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(270)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(300)"/>
+      <rect x="-10" y="-108" width="20" height="22" rx="3" transform="rotate(330)"/>
+    </g>
+    <!-- Spokes -->
+    <g stroke="#10b981" stroke-width="1.5" opacity="0.5">
+      <line x1="0" y1="0" x2="0" y2="-60"/>
+      <line x1="0" y1="0" x2="52" y2="30"/>
+      <line x1="0" y1="0" x2="-52" y2="30"/>
+      <line x1="0" y1="0" x2="0" y2="60"/>
+      <line x1="0" y1="0" x2="52" y2="-30"/>
+      <line x1="0" y1="0" x2="-52" y2="-30"/>
+    </g>
+    <!-- Inner glow -->
+    <circle r="95" fill="url(#glowGear)" filter="url(#gearBlurSm)" opacity="0.6"/>
+  </g>
+
+  <!-- Gear 2 (medium, center) - 8 teeth -->
+  <g transform="translate(650, 220)">
+    <circle r="65" fill="#040e1c" stroke="#3b82f6" stroke-width="2"/>
+    <circle r="46" fill="#040e1c" stroke="#3b82f6" stroke-width="1.5"/>
+    <circle r="16" fill="#3b82f6" opacity="0.3"/>
+    <circle r="8" fill="#3b82f6"/>
+    <!-- Teeth (8) -->
+    <g fill="#040e1c" stroke="#3b82f6" stroke-width="1.5">
+      <rect x="-8" y="-76" width="16" height="18" rx="3"/>
+      <rect x="-8" y="-76" width="16" height="18" rx="3" transform="rotate(45)"/>
+      <rect x="-8" y="-76" width="16" height="18" rx="3" transform="rotate(90)"/>
+      <rect x="-8" y="-76" width="16" height="18" rx="3" transform="rotate(135)"/>
+      <rect x="-8" y="-76" width="16" height="18" rx="3" transform="rotate(180)"/>
+      <rect x="-8" y="-76" width="16" height="18" rx="3" transform="rotate(225)"/>
+      <rect x="-8" y="-76" width="16" height="18" rx="3" transform="rotate(270)"/>
+      <rect x="-8" y="-76" width="16" height="18" rx="3" transform="rotate(315)"/>
+    </g>
+    <g stroke="#3b82f6" stroke-width="1.5" opacity="0.5">
+      <line x1="0" y1="0" x2="0" y2="-40"/>
+      <line x1="0" y1="0" x2="40" y2="0"/>
+      <line x1="0" y1="0" x2="0" y2="40"/>
+      <line x1="0" y1="0" x2="-40" y2="0"/>
+    </g>
+  </g>
+
+  <!-- Gear 3 (medium, center-bottom) - 8 teeth -->
+  <g transform="translate(650, 380)">
+    <circle r="55" fill="#040e1c" stroke="#6366f1" stroke-width="2"/>
+    <circle r="38" fill="#040e1c" stroke="#6366f1" stroke-width="1.5"/>
+    <circle r="12" fill="#6366f1" opacity="0.3"/>
+    <circle r="7" fill="#6366f1"/>
+    <g fill="#040e1c" stroke="#6366f1" stroke-width="1.5">
+      <rect x="-7" y="-64" width="14" height="16" rx="3"/>
+      <rect x="-7" y="-64" width="14" height="16" rx="3" transform="rotate(45)"/>
+      <rect x="-7" y="-64" width="14" height="16" rx="3" transform="rotate(90)"/>
+      <rect x="-7" y="-64" width="14" height="16" rx="3" transform="rotate(135)"/>
+      <rect x="-7" y="-64" width="14" height="16" rx="3" transform="rotate(180)"/>
+      <rect x="-7" y="-64" width="14" height="16" rx="3" transform="rotate(225)"/>
+      <rect x="-7" y="-64" width="14" height="16" rx="3" transform="rotate(270)"/>
+      <rect x="-7" y="-64" width="14" height="16" rx="3" transform="rotate(315)"/>
+    </g>
+    <g stroke="#6366f1" stroke-width="1.5" opacity="0.5">
+      <line x1="0" y1="0" x2="0" y2="-34"/>
+      <line x1="0" y1="0" x2="34" y2="0"/>
+      <line x1="0" y1="0" x2="0" y2="34"/>
+      <line x1="0" y1="0" x2="-34" y2="0"/>
+    </g>
+  </g>
+
+  <!-- Gear 4 (small, right) - 6 teeth -->
+  <g transform="translate(920, 300)">
+    <circle r="80" fill="#040e1c" stroke="#f59e0b" stroke-width="2"/>
+    <circle r="56" fill="#040e1c" stroke="#f59e0b" stroke-width="1.5"/>
+    <circle r="18" fill="#f59e0b" opacity="0.25"/>
+    <circle r="10" fill="#f59e0b"/>
+    <g fill="#040e1c" stroke="#f59e0b" stroke-width="1.5">
+      <rect x="-8" y="-92" width="16" height="20" rx="3"/>
+      <rect x="-8" y="-92" width="16" height="20" rx="3" transform="rotate(60)"/>
+      <rect x="-8" y="-92" width="16" height="20" rx="3" transform="rotate(120)"/>
+      <rect x="-8" y="-92" width="16" height="20" rx="3" transform="rotate(180)"/>
+      <rect x="-8" y="-92" width="16" height="20" rx="3" transform="rotate(240)"/>
+      <rect x="-8" y="-92" width="16" height="20" rx="3" transform="rotate(300)"/>
+    </g>
+    <g stroke="#f59e0b" stroke-width="1.5" opacity="0.5">
+      <line x1="0" y1="0" x2="0" y2="-50"/>
+      <line x1="0" y1="0" x2="43" y2="25"/>
+      <line x1="0" y1="0" x2="-43" y2="25"/>
+      <line x1="0" y1="0" x2="0" y2="50"/>
+      <line x1="0" y1="0" x2="43" y2="-25"/>
+      <line x1="0" y1="0" x2="-43" y2="-25"/>
+    </g>
+  </g>
+
+  <!-- Connecting lines between gears -->
+  <line x1="415" y1="280" x2="585" y2="230" stroke="#10b981" stroke-width="1" stroke-dasharray="4 4" opacity="0.4"/>
+  <line x1="415" y1="290" x2="595" y2="355" stroke="#10b981" stroke-width="1" stroke-dasharray="4 4" opacity="0.4"/>
+  <line x1="715" y1="230" x2="840" y2="260" stroke="#3b82f6" stroke-width="1" stroke-dasharray="4 4" opacity="0.4"/>
+  <line x1="705" y1="380" x2="840" y2="340" stroke="#6366f1" stroke-width="1" stroke-dasharray="4 4" opacity="0.4"/>
+
+  <!-- Efficiency metrics on right -->
+  <g transform="translate(1070, 140)">
+    <text x="0" y="0" font-family="'Arial', sans-serif" font-size="11" fill="#94a3b8" letter-spacing="2">ЭФФЕКТИВНОСТЬ</text>
+    <rect x="0" y="10" width="100" height="8" rx="4" fill="#0d1f3a"/>
+    <rect x="0" y="10" width="87" height="8" rx="4" fill="#10b981" opacity="0.8"/>
+    <text x="105" y="20" font-family="'Arial', sans-serif" font-size="10" fill="#10b981">87%</text>
+  </g>
+  <g transform="translate(1070, 180)">
+    <text x="0" y="0" font-family="'Arial', sans-serif" font-size="11" fill="#94a3b8" letter-spacing="2">СКОРОСТЬ</text>
+    <rect x="0" y="10" width="100" height="8" rx="4" fill="#0d1f3a"/>
+    <rect x="0" y="10" width="95" height="8" rx="4" fill="#3b82f6" opacity="0.8"/>
+    <text x="105" y="20" font-family="'Arial', sans-serif" font-size="10" fill="#3b82f6">95%</text>
+  </g>
+  <g transform="translate(1070, 220)">
+    <text x="0" y="0" font-family="'Arial', sans-serif" font-size="11" fill="#94a3b8" letter-spacing="2">ТОЧНОСТЬ</text>
+    <rect x="0" y="10" width="100" height="8" rx="4" fill="#0d1f3a"/>
+    <rect x="0" y="10" width="99" height="8" rx="4" fill="#f59e0b" opacity="0.8"/>
+    <text x="105" y="20" font-family="'Arial', sans-serif" font-size="10" fill="#f59e0b">99%</text>
+  </g>
+
+  <!-- Bottom bar -->
+  <rect x="0" y="570" width="1200" height="58" fill="#020c18" opacity="0.9"/>
+  <text x="60" y="603" font-family="'Arial', sans-serif" font-size="28" fill="white" font-weight="700">Backlogram</text>
+  <text x="60" y="622" font-family="'Arial', sans-serif" font-size="11" fill="#94a3b8" letter-spacing="2">ПРОЦЕССЫ ПОД КОНТРОЛЕМ. ВСЕГДА.</text>
+  <text x="1140" y="610" font-family="'Arial', sans-serif" font-size="12" fill="#10b981" text-anchor="end" letter-spacing="1">backlogram.ru</text>
+</svg>

--- a/public/ad-images/ad-5-data-wave.svg
+++ b/public/ad-images/ad-5-data-wave.svg
@@ -1,0 +1,135 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="628" viewBox="0 0 1200 628">
+  <defs>
+    <linearGradient id="bg5" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#040a18"/>
+      <stop offset="100%" stop-color="#080418"/>
+    </linearGradient>
+    <linearGradient id="wave1Grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#6366f1" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#6366f1"/>
+      <stop offset="70%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="wave2Grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#8b5cf6"/>
+      <stop offset="70%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="wave3Grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#10b981" stop-opacity="0"/>
+      <stop offset="40%" stop-color="#10b981"/>
+      <stop offset="60%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="fillGrad1" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#6366f1" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="fillGrad2" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/>
+    </linearGradient>
+    <filter id="waveBlur">
+      <feGaussianBlur stdDeviation="2"/>
+    </filter>
+    <filter id="waveBigBlur">
+      <feGaussianBlur stdDeviation="16"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="628" fill="url(#bg5)"/>
+
+  <!-- Background glow -->
+  <ellipse cx="600" cy="320" rx="500" ry="200" fill="#6366f1" opacity="0.04" filter="url(#waveBigBlur)"/>
+
+  <!-- Vertical bar chart / histogram -->
+  <g opacity="0.15">
+    <rect x="60" y="400" width="20" height="80" fill="#6366f1"/>
+    <rect x="90" y="360" width="20" height="120" fill="#6366f1"/>
+    <rect x="120" y="380" width="20" height="100" fill="#6366f1"/>
+    <rect x="150" y="340" width="20" height="140" fill="#6366f1"/>
+    <rect x="180" y="300" width="20" height="180" fill="#8b5cf6"/>
+    <rect x="210" y="320" width="20" height="160" fill="#8b5cf6"/>
+    <rect x="240" y="280" width="20" height="200" fill="#8b5cf6"/>
+    <rect x="270" y="260" width="20" height="220" fill="#8b5cf6"/>
+    <rect x="300" y="240" width="20" height="240" fill="#6366f1"/>
+    <rect x="330" y="220" width="20" height="260" fill="#6366f1"/>
+    <rect x="360" y="240" width="20" height="240" fill="#6366f1"/>
+    <rect x="390" y="200" width="20" height="280" fill="#06b6d4"/>
+    <rect x="420" y="180" width="20" height="300" fill="#06b6d4"/>
+    <rect x="450" y="200" width="20" height="280" fill="#06b6d4"/>
+    <rect x="480" y="160" width="20" height="320" fill="#06b6d4"/>
+    <rect x="510" y="140" width="20" height="340" fill="#10b981"/>
+    <rect x="540" y="120" width="20" height="360" fill="#10b981"/>
+    <rect x="570" y="100" width="20" height="380" fill="#10b981"/>
+    <rect x="600" y="120" width="20" height="360" fill="#10b981"/>
+    <rect x="630" y="100" width="20" height="380" fill="#10b981"/>
+    <rect x="660" y="80" width="20" height="400" fill="#10b981"/>
+    <rect x="690" y="100" width="20" height="380" fill="#10b981"/>
+    <rect x="720" y="120" width="20" height="360" fill="#06b6d4"/>
+    <rect x="750" y="140" width="20" height="340" fill="#06b6d4"/>
+    <rect x="780" y="160" width="20" height="320" fill="#06b6d4"/>
+    <rect x="810" y="140" width="20" height="340" fill="#3b82f6"/>
+    <rect x="840" y="120" width="20" height="360" fill="#3b82f6"/>
+    <rect x="870" y="100" width="20" height="380" fill="#3b82f6"/>
+    <rect x="900" y="80" width="20" height="400" fill="#3b82f6"/>
+    <rect x="930" y="100" width="20" height="380" fill="#3b82f6"/>
+    <rect x="960" y="120" width="20" height="360" fill="#6366f1"/>
+    <rect x="990" y="140" width="20" height="340" fill="#6366f1"/>
+    <rect x="1020" y="160" width="20" height="320" fill="#6366f1"/>
+    <rect x="1050" y="200" width="20" height="280" fill="#8b5cf6"/>
+    <rect x="1080" y="220" width="20" height="260" fill="#8b5cf6"/>
+    <rect x="1110" y="260" width="20" height="220" fill="#8b5cf6"/>
+  </g>
+
+  <!-- Wave 1 (bottom) -->
+  <path d="M 0,420 C 100,380 150,440 250,410 C 350,380 400,430 500,400 C 600,370 650,430 750,400 C 850,370 900,420 1000,390 C 1100,360 1150,400 1200,380 L 1200,628 L 0,628 Z"
+    fill="url(#fillGrad2)" opacity="0.6"/>
+  <path d="M 0,420 C 100,380 150,440 250,410 C 350,380 400,430 500,400 C 600,370 650,430 750,400 C 850,370 900,420 1000,390 C 1100,360 1150,400 1200,380"
+    fill="none" stroke="url(#wave2Grad)" stroke-width="2.5" opacity="0.7"/>
+
+  <!-- Wave 2 (middle) -->
+  <path d="M 0,350 C 80,300 160,370 280,330 C 400,290 460,360 560,320 C 660,280 720,360 820,320 C 920,280 980,350 1080,310 C 1140,285 1180,330 1200,300 L 1200,628 L 0,628 Z"
+    fill="url(#fillGrad1)" opacity="0.5"/>
+  <path d="M 0,350 C 80,300 160,370 280,330 C 400,290 460,360 560,320 C 660,280 720,360 820,320 C 920,280 980,350 1080,310 C 1140,285 1180,330 1200,300"
+    fill="none" stroke="url(#wave1Grad)" stroke-width="3" opacity="0.9"/>
+  <!-- Glow on main wave -->
+  <path d="M 0,350 C 80,300 160,370 280,330 C 400,290 460,360 560,320 C 660,280 720,360 820,320 C 920,280 980,350 1080,310 C 1140,285 1180,330 1200,300"
+    fill="none" stroke="url(#wave1Grad)" stroke-width="6" opacity="0.25" filter="url(#waveBlur)"/>
+
+  <!-- Wave 3 (top, thinner) -->
+  <path d="M 0,260 C 60,230 120,270 200,250 C 300,225 380,265 480,240 C 580,215 640,255 740,230 C 840,205 900,240 1000,215 C 1080,195 1140,225 1200,210"
+    fill="none" stroke="url(#wave3Grad)" stroke-width="1.5" opacity="0.6"/>
+
+  <!-- Data points on main wave -->
+  <circle cx="280" cy="330" r="5" fill="#6366f1"/>
+  <circle cx="280" cy="330" r="10" fill="#6366f1" opacity="0.3" filter="url(#waveBlur)"/>
+  <line x1="280" y1="280" x2="280" y2="330" stroke="#6366f1" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/>
+  <text x="280" y="272" font-family="'Courier New', monospace" font-size="11" fill="#6366f1" text-anchor="middle">+42%</text>
+
+  <circle cx="560" cy="320" r="5" fill="#06b6d4"/>
+  <circle cx="560" cy="320" r="10" fill="#06b6d4" opacity="0.3" filter="url(#waveBlur)"/>
+  <line x1="560" y1="270" x2="560" y2="320" stroke="#06b6d4" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/>
+  <text x="560" y="262" font-family="'Courier New', monospace" font-size="11" fill="#06b6d4" text-anchor="middle">×3 быстрее</text>
+
+  <circle cx="820" cy="320" r="5" fill="#10b981"/>
+  <circle cx="820" cy="320" r="10" fill="#10b981" opacity="0.3" filter="url(#waveBlur)"/>
+  <line x1="820" y1="270" x2="820" y2="320" stroke="#10b981" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/>
+  <text x="820" y="262" font-family="'Courier New', monospace" font-size="11" fill="#10b981" text-anchor="middle">-60% ошибок</text>
+
+  <circle cx="1080" cy="310" r="5" fill="#8b5cf6"/>
+  <circle cx="1080" cy="310" r="10" fill="#8b5cf6" opacity="0.3" filter="url(#waveBlur)"/>
+  <line x1="1080" y1="260" x2="1080" y2="310" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/>
+  <text x="1080" y="252" font-family="'Courier New', monospace" font-size="11" fill="#8b5cf6" text-anchor="middle">ROI 300%</text>
+
+  <!-- Headline -->
+  <text x="600" y="140" font-family="'Arial', sans-serif" font-size="44" fill="white" text-anchor="middle" font-weight="900" letter-spacing="-1" opacity="0.95">АВТОМАТИЗАЦИЯ</text>
+  <text x="600" y="185" font-family="'Arial', sans-serif" font-size="20" fill="#94a3b8" text-anchor="middle" font-weight="400" letter-spacing="8">МЕНЯЕТ ПОКАЗАТЕЛИ</text>
+
+  <!-- Bottom bar -->
+  <rect x="0" y="570" width="1200" height="58" fill="#040a18" opacity="0.95"/>
+  <text x="60" y="603" font-family="'Arial', sans-serif" font-size="28" fill="white" font-weight="700">Backlogram</text>
+  <text x="60" y="622" font-family="'Arial', sans-serif" font-size="11" fill="#94a3b8" letter-spacing="2">ДАННЫЕ ГОВОРЯТ ЗА СЕБЯ</text>
+  <text x="1140" y="610" font-family="'Arial', sans-serif" font-size="12" fill="#10b981" text-anchor="end" letter-spacing="1">backlogram.ru</text>
+</svg>

--- a/src/pages/AdImages.tsx
+++ b/src/pages/AdImages.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+
+const ads = [
+  {
+    id: 1,
+    file: '/ad-images/ad-1-neural-flow.svg',
+    title: 'Нейронная сеть',
+    description: 'Абстрактная нейросеть — узлы, связи, активные сигналы. Тема: ИИ-автоматизация.',
+  },
+  {
+    id: 2,
+    file: '/ad-images/ad-2-data-circuit.svg',
+    title: 'Цифровая плата',
+    description: 'Дорожки печатной платы с чипом AUTO CORE в центре. Тема: технологическая основа автоматизации.',
+  },
+  {
+    id: 3,
+    file: '/ad-images/ad-3-infinity-loop.svg',
+    title: 'Замкнутый цикл',
+    description: 'Знак бесконечности — замкнутый цикл данных, анализа и действий. Тема: непрерывная автоматизация.',
+  },
+  {
+    id: 4,
+    file: '/ad-images/ad-4-gear-flow.svg',
+    title: 'Шестерни процессов',
+    description: 'Сцепленные шестерни с метриками эффективности. Тема: точность и слаженность процессов.',
+  },
+  {
+    id: 5,
+    file: '/ad-images/ad-5-data-wave.svg',
+    title: 'Волна данных',
+    description: 'Волновой график роста с аннотациями ключевых метрик. Тема: измеримые результаты автоматизации.',
+  },
+]
+
+export default function AdImages() {
+  const [selected, setSelected] = React.useState<number | null>(null)
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white py-12 px-6">
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-3xl font-bold mb-2">Рекламные баннеры — Яндекс Директ</h1>
+        <p className="text-gray-400 mb-10 text-sm">
+          5 абстрактных баннеров про автоматизацию · формат 1200×628 px · SVG
+        </p>
+
+        <div className="grid grid-cols-1 gap-10">
+          {ads.map((ad) => (
+            <div key={ad.id} className="rounded-xl overflow-hidden border border-gray-800 bg-gray-900">
+              <img
+                src={ad.file}
+                alt={ad.title}
+                className="w-full block cursor-zoom-in"
+                onClick={() => setSelected(ad.id)}
+              />
+              <div className="p-4 flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="font-semibold text-lg mb-1">
+                    #{ad.id} — {ad.title}
+                  </h2>
+                  <p className="text-gray-400 text-sm">{ad.description}</p>
+                </div>
+                <a
+                  href={ad.file}
+                  download
+                  className="shrink-0 px-4 py-2 bg-indigo-600 hover:bg-indigo-500 rounded-lg text-sm font-medium transition-colors"
+                >
+                  Скачать SVG
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {selected !== null && (
+        <div
+          className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4"
+          onClick={() => setSelected(null)}
+        >
+          <img
+            src={ads[selected - 1].file}
+            alt={ads[selected - 1].title}
+            className="max-w-full max-h-full rounded-xl shadow-2xl"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,6 +4,7 @@ import NotFound from './pages/NotFound'
 import Success from './pages/Success'
 import Fail from './pages/Fail'
 import Tokens from './pages/Tokens'
+import AdImages from './pages/AdImages'
 import App from './App'
 
 export const router = createBrowserRouter([
@@ -26,6 +27,10 @@ export const router = createBrowserRouter([
       {
         path: 'tokens.html',
         element: <Tokens />,
+      },
+      {
+        path: 'ad-images.html',
+        element: <AdImages />,
       },
       {
         path: '*',


### PR DESCRIPTION
## Summary

Closes #116.

Generates **5 abstract, modern SVG banners** (1200×628 px) for Yandex Direct advertising campaign, each conveying automation with a distinct visual theme.

| # | Файл | Концепция |
|---|------|-----------|
| 1 | `ad-1-neural-flow.svg` | Нейронная сеть — узлы, синапсы, активный сигнальный путь |
| 2 | `ad-2-data-circuit.svg` | Печатная плата — дорожки, чип `AUTO CORE`, живые трассы |
| 3 | `ad-3-infinity-loop.svg` | Знак ∞ — замкнутый цикл: данные → анализ → решение → результат |
| 4 | `ad-4-gear-flow.svg` | Сцепленные шестерни с метриками: эффективность 87%, скорость 95%, точность 99% |
| 5 | `ad-5-data-wave.svg` | Волновой график роста с аннотациями: +42%, ×3 быстрее, −60% ошибок, ROI 300% |

All banners use the site's dark tech palette (indigo/cyan/purple) and include the `Backlogram` brand name and `backlogram.ru` URL.

## Preview page

Added `/ad-images.html` — a React page to review all banners in-browser with download links.

## Files changed

- `public/ad-images/ad-{1..5}-*.svg` — 5 SVG banners
- `src/pages/AdImages.tsx` — preview/download gallery page
- `src/router.tsx` — adds `/ad-images.html` route

## Test plan

- [x] All 4 existing tests pass (`npm run test`)
- [ ] Open `/ad-images.html` in browser to preview banners
- [ ] Download each SVG and verify it opens at 1200×628 px
- [ ] Upload to Yandex Direct campaign