### PR TITLE
Show CTA captcha after contact input

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
-# Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-04-27T11:20:41.070Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,2 @@
+# .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
+# Updated: 2026-04-05T10:21:17.400Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-04-27T11:20:41.070Z

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -63,11 +63,12 @@ export default function Home() {
   const [errorMsg, setErrorMsg]   = React.useState('')
   const [consentChecked, setConsentChecked] = React.useState(false)
   const [captchaToken, setCaptchaToken] = React.useState('')
+  const [isCaptchaRequested, setIsCaptchaRequested] = React.useState(false)
   const captchaContainerRef = React.useRef<HTMLDivElement>(null)
   const captchaWidgetIdRef = React.useRef<number | null>(null)
 
   React.useEffect(() => {
-    if (!CAPTCHA_CLIENT_KEY) return
+    if (!CAPTCHA_CLIENT_KEY || !isCaptchaRequested) return
 
     function initCaptcha() {
       if (!captchaContainerRef.current || !window.smartCaptcha) return
@@ -93,9 +94,10 @@ export default function Home() {
     return () => {
       if (captchaWidgetIdRef.current !== null && window.smartCaptcha) {
         window.smartCaptcha.destroy(captchaWidgetIdRef.current)
+        captchaWidgetIdRef.current = null
       }
     }
-  }, [])
+  }, [isCaptchaRequested])
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -130,7 +132,8 @@ export default function Home() {
         setFormState('success')
         form.reset()
         setCaptchaToken('')
-        if (captchaWidgetIdRef.current !== null && window.smartCaptcha) {
+        setIsCaptchaRequested(false)
+        if (captchaWidgetIdRef.current !== null && window.smartCaptcha && captchaContainerRef.current) {
           window.smartCaptcha.reset(captchaWidgetIdRef.current)
         }
       } else {
@@ -1022,7 +1025,7 @@ export default function Home() {
                 </div>
                 <div>
                   <label className="block text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2 ml-1">Email / Telegram</label>
-                  <input name="contact" type="text" className="w-full bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-2 sm:py-3 text-slate-800 dark:text-slate-100 focus:border-blue-500 outline-none transition-all" placeholder="@username" />
+                  <input name="contact" type="text" onInput={() => setIsCaptchaRequested(true)} className="w-full bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-2 sm:py-3 text-slate-800 dark:text-slate-100 focus:border-blue-500 outline-none transition-all" placeholder="@username" />
                 </div>
                 <div>
                   <label className="block text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2 ml-1">Задача (коротко)</label>
@@ -1039,7 +1042,7 @@ export default function Home() {
                   <div className="text-red-500 dark:text-red-400 text-sm font-medium">{errorMsg}</div>
                 )}
 
-                {CAPTCHA_CLIENT_KEY && (
+                {CAPTCHA_CLIENT_KEY && isCaptchaRequested && (
                   <div ref={captchaContainerRef} />
                 )}
 

--- a/tests/cta-captcha.test.mjs
+++ b/tests/cta-captcha.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const homeSource = readFileSync(new URL('../src/pages/Home.tsx', import.meta.url), 'utf8')
+
+test('CTA captcha is hidden until the contact field receives user input', () => {
+  assert.match(
+    homeSource,
+    /const \[isCaptchaRequested, setIsCaptchaRequested\] = React\.useState\(false\)/,
+    'CTA should track whether the visitor started entering Email / Telegram.',
+  )
+  assert.match(
+    homeSource,
+    /if \(!CAPTCHA_CLIENT_KEY \|\| !isCaptchaRequested\) return/,
+    'SmartCaptcha should not load or render before Email / Telegram input starts.',
+  )
+  assert.match(
+    homeSource,
+    /onInput=\{\(\) => setIsCaptchaRequested\(true\)\}/,
+    'Email / Telegram input should request the captcha once the visitor types.',
+  )
+  assert.match(
+    homeSource,
+    /\{CAPTCHA_CLIENT_KEY && isCaptchaRequested && \(/,
+    'Captcha container should not be visible before the visitor types.',
+  )
+})


### PR DESCRIPTION
## Summary
- Defer SmartCaptcha script/rendering in the #cta form until the visitor starts typing in Email / Telegram.
- Hide the captcha container before contact input and reset the request state after a successful submission.
- Add a regression test that checks the delayed captcha behavior.

## Reproduction
Before this change, loading the page with VITE_SMARTCAPTCHA_CLIENT_KEY set rendered the SmartCaptcha container immediately because the effect ran on initial mount.

## Tests
- npm test
- npm run build

Fixes #120