### PR TITLE
Добавь якорь AI section

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-04-30T21:47:28.349Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-04-30T21:47:28.349Z

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -485,7 +485,7 @@ export default function Home() {
       </section>
 
       {/* 6. AI Section */}
-      <section className="py-24 bg-slate-50 dark:bg-slate-900/50 relative overflow-hidden">
+      <section id="ai" className="py-24 bg-slate-50 dark:bg-slate-900/50 relative overflow-hidden">
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[700px] bg-blue-600/5 blur-[100px] rounded-full -z-10" />
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/tests/home-anchor.test.mjs
+++ b/tests/home-anchor.test.mjs
@@ -32,3 +32,8 @@ test('special case CTA link stays in the current tab and lands below the fixed h
     'CTA target needs scroll margin so the fixed header does not cover it',
   )
 })
+
+test('AI section exposes an in-page anchor for ad links', () => {
+  const aiSection = homeSource.match(/\/\* 6\. AI Section \*\/[\s\S]*?<section\s+id="ai"\s+className="([^"]+)"/)
+  assert.ok(aiSection, 'Expected the AI section to expose id="ai"')
+})


### PR DESCRIPTION
## Summary
- Added `id="ai"` to the 6. AI section so advertising links can target `#ai`.
- Added a regression test that verifies the AI section exposes the anchor.

## Tests
- `npm test`
- `npm run build`

Fixes #122