### PR TITLE
Skip captcha for visitors with a valid idb_* cookie

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-05-01T06:07:14.449Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-05-01T06:07:14.449Z

--- a/public/telegram-notify.php
+++ b/public/telegram-notify.php
@@ -95,8 +95,10 @@ function verifyCaptcha(string $token): bool {
     return isset($res_data['status']) && $res_data['status'] === 'ok';
 }
 
+$hasIdbCookie = (bool) preg_grep('/^idb_/', array_keys($_COOKIE));
+
 $captchaToken = trim($data['captcha_token'] ?? '');
-if (!verifyCaptcha($captchaToken)) {
+if (!$hasIdbCookie && !verifyCaptcha($captchaToken)) {
     http_response_code(400);
     echo json_encode(['ok' => false, 'error' => 'Проверка капчи не пройдена. Попробуйте ещё раз.']);
     exit;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -58,17 +58,22 @@ type FormState = 'idle' | 'sending' | 'success' | 'error'
 
 const CAPTCHA_CLIENT_KEY = (import.meta.env.VITE_SMARTCAPTCHA_CLIENT_KEY as string | undefined) ?? ''
 
+function hasIdbCookie(): boolean {
+  return document.cookie.split(';').some(c => c.trimStart().startsWith('idb_'))
+}
+
 export default function Home() {
   const [formState, setFormState] = React.useState<FormState>('idle')
   const [errorMsg, setErrorMsg]   = React.useState('')
   const [consentChecked, setConsentChecked] = React.useState(false)
   const [captchaToken, setCaptchaToken] = React.useState('')
   const [isCaptchaRequested, setIsCaptchaRequested] = React.useState(false)
+  const [idbCookieFound] = React.useState(() => hasIdbCookie())
   const captchaContainerRef = React.useRef<HTMLDivElement>(null)
   const captchaWidgetIdRef = React.useRef<number | null>(null)
 
   React.useEffect(() => {
-    if (!CAPTCHA_CLIENT_KEY || !isCaptchaRequested) return
+    if (!CAPTCHA_CLIENT_KEY || !isCaptchaRequested || idbCookieFound) return
 
     function initCaptcha() {
       if (!captchaContainerRef.current || !window.smartCaptcha) return
@@ -109,7 +114,7 @@ export default function Home() {
       task:    (form.elements.namedItem('task')    as HTMLTextAreaElement).value,
     }
 
-    if (CAPTCHA_CLIENT_KEY) {
+    if (CAPTCHA_CLIENT_KEY && !idbCookieFound) {
       if (!captchaToken) {
         setErrorMsg('Пожалуйста, пройдите проверку капчи.')
         setFormState('error')
@@ -1042,7 +1047,7 @@ export default function Home() {
                   <div className="text-red-500 dark:text-red-400 text-sm font-medium">{errorMsg}</div>
                 )}
 
-                {CAPTCHA_CLIENT_KEY && isCaptchaRequested && (
+                {CAPTCHA_CLIENT_KEY && !idbCookieFound && isCaptchaRequested && (
                   <div ref={captchaContainerRef} />
                 )}
 

--- a/tests/cta-captcha.test.mjs
+++ b/tests/cta-captcha.test.mjs
@@ -12,8 +12,8 @@ test('CTA captcha is hidden until the contact field receives user input', () => 
   )
   assert.match(
     homeSource,
-    /if \(!CAPTCHA_CLIENT_KEY \|\| !isCaptchaRequested\) return/,
-    'SmartCaptcha should not load or render before Email / Telegram input starts.',
+    /if \(!CAPTCHA_CLIENT_KEY \|\| !isCaptchaRequested \|\| idbCookieFound\) return/,
+    'SmartCaptcha should not load or render before Email / Telegram input starts, or when idb_* cookie is present.',
   )
   assert.match(
     homeSource,
@@ -22,7 +22,30 @@ test('CTA captcha is hidden until the contact field receives user input', () => 
   )
   assert.match(
     homeSource,
-    /\{CAPTCHA_CLIENT_KEY && isCaptchaRequested && \(/,
-    'Captcha container should not be visible before the visitor types.',
+    /\{CAPTCHA_CLIENT_KEY && !idbCookieFound && isCaptchaRequested && \(/,
+    'Captcha container should not be visible before the visitor types, or when idb_* cookie is present.',
+  )
+})
+
+test('CTA captcha is skipped for visitors with a valid idb_* cookie', () => {
+  assert.match(
+    homeSource,
+    /function hasIdbCookie\(\): boolean/,
+    'hasIdbCookie helper function should be defined.',
+  )
+  assert.match(
+    homeSource,
+    /document\.cookie\.split\(';'\)\.some\(c => c\.trimStart\(\)\.startsWith\('idb_'\)\)/,
+    'hasIdbCookie should check document.cookie for any idb_* prefix.',
+  )
+  assert.match(
+    homeSource,
+    /const \[idbCookieFound\] = React\.useState\(\(\) => hasIdbCookie\(\)\)/,
+    'idbCookieFound state should be initialised from hasIdbCookie().',
+  )
+  assert.match(
+    homeSource,
+    /if \(CAPTCHA_CLIENT_KEY && !idbCookieFound\)/,
+    'Captcha token should not be required when an idb_* cookie is present.',
   )
 })


### PR DESCRIPTION
## Summary

- Add `hasIdbCookie()` helper in `Home.tsx` that checks `document.cookie` for any `idb_*` prefix.
- When an `idb_*` cookie is present, the SmartCaptcha widget is neither shown nor loaded, and the captcha token is not required on form submit.
- In `telegram-notify.php`, captcha verification is skipped when any `idb_*` cookie is present in `$_COOKIE`.
- Updated `tests/cta-captcha.test.mjs` with a new test that validates the bypass behaviour and updated the existing test to match the new effect guard condition.

## How to reproduce the original issue

With `VITE_SMARTCAPTCHA_CLIENT_KEY` set, the captcha widget always appeared for every visitor once they started typing their contact details — even returning users who already had Yandex identity (`idb_*`) cookies.

## Test plan

- [x] `npm test` — all 7 tests pass
- Manual: set an `idb_test=1` cookie in the browser, open the CTA form, start typing in the contact field → captcha widget should not appear
- Manual: without any `idb_*` cookie → captcha widget should appear as before

Fixes #124