### PR TITLE
Skip SmartCaptcha on start.html for visitors with an idb_* cookie

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-05-01T06:18:18.906Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-05-01T06:18:18.906Z

--- a/start.html
+++ b/start.html
@@ -20,5 +20,23 @@
     </script>
     <noscript><div><img src="https://mc.yandex.ru/watch/108758829" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
     <!-- /Yandex.Metrika counter -->
+
+    <!-- Skip SmartCaptcha for registered visitors (those with an idb_* cookie) -->
+    <script>
+      (function () {
+        var hasIdb = document.cookie.split(';').some(function (c) {
+          return c.trimStart().indexOf('idb_') === 0;
+        });
+        if (hasIdb) {
+          document.documentElement.setAttribute('data-skip-captcha', '1');
+          document.addEventListener('DOMContentLoaded', function () {
+            var captchaEls = document.querySelectorAll('.smartcaptcha-wrapper, [data-smartcaptcha]');
+            captchaEls.forEach(function (el) { el.style.display = 'none'; });
+            var tokenInputs = document.querySelectorAll('input[name="smart-token"]');
+            tokenInputs.forEach(function (el) { el.value = 'skip'; });
+          });
+        }
+      })();
+    </script>
   </body>
 </html>

--- a/tests/start-captcha-skip.test.mjs
+++ b/tests/start-captcha-skip.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const startSource = readFileSync(new URL('../start.html', import.meta.url), 'utf8')
+
+test('start.html skips SmartCaptcha for visitors with a valid idb_* cookie', () => {
+  assert.match(
+    startSource,
+    /document\.cookie\.split\(';'\)\.some\(function \(c\) \{/,
+    'should split document.cookie to check for idb_* cookies',
+  )
+  assert.match(
+    startSource,
+    /c\.trimStart\(\)\.indexOf\('idb_'\) === 0/,
+    'should detect any idb_* cookie prefix',
+  )
+  assert.match(
+    startSource,
+    /data-skip-captcha/,
+    'should mark the page as captcha-skipped via data-skip-captcha attribute',
+  )
+  assert.match(
+    startSource,
+    /\.smartcaptcha-wrapper|data-smartcaptcha/,
+    'should hide the SmartCaptcha widget element when idb_* cookie is present',
+  )
+  assert.match(
+    startSource,
+    /input\[name="smart-token"\]/,
+    'should set a placeholder captcha token so the form can submit without a real captcha',
+  )
+})


### PR DESCRIPTION
## Summary

- Add an inline script to `start.html` that detects any `idb_*` cookie (Yandex identity tokens present for registered users).
- When such a cookie is found, the SmartCaptcha widget elements (`.smartcaptcha-wrapper`, `[data-smartcaptcha]`) are hidden and a placeholder token is injected into `input[name="smart-token"]` so the login form can submit without a captcha challenge.
- The `data-skip-captcha="1"` attribute is set on `<html>` so that any additional page-level logic (e.g. in index.php) can also detect and skip server-side captcha verification.
- Add `tests/start-captcha-skip.test.mjs` to verify the bypass behaviour.

## How to reproduce the original issue

With SmartCaptcha configured in the server-side login page, **every** visitor to `start.html` (including already-registered users with valid Yandex tokens) was shown the captcha challenge — even though those users have `idb_*` cookies that prove they are known to the system.

PR #125 correctly fixed this on the main landing-page CTA form (`Home.tsx` / `telegram-notify.php`), but missed `start.html`, which is the actual login page used by registered users.

## Test plan

- [x] `npm test` — all 9 tests pass
- Manual: set an `idb_test=1` cookie in the browser, open `start.html` → captcha widget should be hidden and the form should submit without a token
- Manual: without any `idb_*` cookie → captcha widget behaves normally

Fixes #126