### PR TITLE
Skip login captcha when any idb_* cookie exists, not just idb_$z

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
-# Updated: 2026-05-01T07:23:00.501Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-04T09:06:41.567Z for PR creation at branch issue-60-f5f5214d820e for issue https://github.com/ideav/backlogram/issues/60
 # Updated: 2026-04-05T10:21:17.400Z
+# Updated: 2026-05-01T07:23:00.501Z

--- a/index.php
+++ b/index.php
@@ -7998,7 +7998,8 @@ switch($a)  # Check actions, which don't require authentication
 			$GLOBALS["tzone"] = round(((int)$_POST["tzone"] - time() - date("Z"))/1800)*1800; # Round the time zone shift to 30 min
 			setcookie("tzone", $GLOBALS["tzone"], time() + COOKIES_EXPIRE, "/"); # 30 days
 		}
-		if(isset($_POST["smart-token"]) && !verifyCaptcha($_POST["smart-token"])){
+		$hasAnyIdbCookie = (bool)preg_grep('/^idb_/', array_keys($_COOKIE));
+		if(isset($_POST["smart-token"]) && !$hasAnyIdbCookie && !verifyCaptcha($_POST["smart-token"])){
 			$captchaMsg = t9n("[RU]Проверка капчи не пройдена. Пожалуйста, попробуйте снова.[EN]Captcha verification failed. Please try again.");
 			if(isApi()){
 				header("HTTP/1.0 403 Forbidden");

--- a/tests/index-captcha-skip.test.mjs
+++ b/tests/index-captcha-skip.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const indexSource = readFileSync(new URL('../index.php', import.meta.url), 'utf8')
+
+test('index.php skips SmartCaptcha verification for users with any idb_* cookie on login', () => {
+  assert.match(
+    indexSource,
+    /preg_grep\('\/\^idb_\/', array_keys\(\$_COOKIE\)\)/,
+    'login should detect any idb_* cookie using preg_grep on array_keys($_COOKIE)',
+  )
+  assert.match(
+    indexSource,
+    /!\$hasAnyIdbCookie && !verifyCaptcha\(\$_POST\["smart-token"\]\)/,
+    'login should skip captcha when any idb_* cookie is present (not just idb_$z)',
+  )
+})


### PR DESCRIPTION
## Summary

- `index.php` login guard now skips `verifyCaptcha()` when the user holds **any** `idb_*` cookie, not just `idb_$z` (the current-database token).
- Added `tests/index-captcha-skip.test.mjs` to verify this behavior.

## Problem

PR #131 fixed captcha skipping only for users who already have a token for the **current** database (`idb_$z`). But a user may be authenticated to a different database and carry an `idb_<other>` cookie. In that case the server still demanded a captcha even though the client already hid the widget — making the form unsubmittable.

## How to reproduce the issue

1. Log in to database A — acquires `idb_A` cookie.
2. Navigate to the login page for database B.
3. The client hides the captcha widget (correct — any `idb_*` cookie is found).
4. Submit the login form → server rejects it with a captcha error (bug — server only checked `idb_$z` i.e. `idb_B`).

## What changed

`index.php` login guard (line 8001):

```php
// Before (PR #131)
if(isset($_POST["smart-token"]) && !isset($_COOKIE["idb_$z"]) && !verifyCaptcha($_POST["smart-token"])){

// After (this PR)
$hasAnyIdbCookie = (bool)preg_grep('/^idb_/', array_keys($_COOKIE));
if(isset($_POST["smart-token"]) && !$hasAnyIdbCookie && !verifyCaptcha($_POST["smart-token"])){
```

This mirrors the client-side `hasIdbCookie()` check already in `src/pages/Home.tsx`.

## Test plan

- [x] `npm test` — all 9 tests pass
- [x] New test `index.php skips SmartCaptcha verification for users with any idb_* cookie on login` passes

Fixes #132