### PR TITLE
Make hero subtitle text black for better contrast

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-03T10:21:44.669Z for PR creation at branch issue-136-63fb2b6892ae for issue https://github.com/ideav/backlogram/issues/136

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -195,7 +195,7 @@ export default function Home() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.2 }}
-              className="max-w-3xl mx-auto text-lg md:text-xl text-slate-500 dark:text-slate-400 leading-relaxed mb-10"
+              className="max-w-3xl mx-auto text-lg md:text-xl text-slate-900 dark:text-slate-100 leading-relaxed mb-10"
             >
               Разгрузите программистов, не жертвуя контролем.<br />
               Платформа, которая встраивается в вашу ИТ-среду и реализует проекты быстрее, чем вы успеете написать ТЗ на обычную разработку.


### PR DESCRIPTION
## Problem

The subtitle text in the hero section ("Разгрузите программистов, не жертвуя контролем." and the following sentence) used muted colors (`text-slate-500` / `dark:text-slate-400`), making it hard to read.

## Solution

Changed the text color to high-contrast `text-slate-900` (near-black) in light mode and `text-slate-100` (near-white) in dark mode.

**File changed:** `src/pages/Home.tsx` line 198

Closes #136