### PR TITLE
Resolve conflicts in PR #190 (split knowledge base article 14)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-12T21:47:09.013Z for PR creation at branch issue-193-07edbb4ef0a9 for issue https://github.com/ideav/backlogram/issues/193


### PR DESCRIPTION
## Summary

Resolves conflicts in [PR #190](https://github.com/ideav/backlogram/pull/190) that split knowledge base article #14 into three separate articles.

Fixes #193

## What was conflicting

PR #190 (branch `issue-173-b58a6f706438`) split article #14 (forms, reports and dashboards) into three articles. In parallel, `main` received an enhanced combined article at the same slug. This caused two conflicts:

- `.gitkeep` — deleted in `main`, modified in PR branch
- `src/data/knowledgeBase.ts` — both branches modified the article #14 entry area

## Resolution

1. **`src/data/knowledgeBase.ts`**: Kept the PR's intent — three separate articles (`14-forms`, `14a-reports`, `14b-dashboards`). Updated `relatedSlugs` in articles #13 and #15 to reference the new slugs instead of the old combined slug `14-forms-reports-dashboards`.

2. **Tests**: Updated `kb-article-13.test.mjs`, `kb-article-14.test.mjs`, `kb-article-15.test.mjs` to match the new split structure.

3. **`.gitkeep`**: Re-added after deletion (the merge with main removed it, but the PR branch uses it).

## Test plan

- [x] All 96 tests pass: `npm test`
- [x] Branch is up to date with `main`
- [x] No remaining merge conflict markers