### PR TITLE
Поиск по базе знаний и SEO для страницы базы знаний

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-12T21:42:45.606Z for PR creation at branch issue-192-e611c6e9886b for issue https://github.com/ideav/backlogram/issues/192
+# Updated: 2026-05-13T06:55:37.946Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-12T21:42:45.606Z for PR creation at branch issue-192-e611c6e9886b for issue https://github.com/ideav/backlogram/issues/192
-# Updated: 2026-05-13T06:55:37.946Z

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,8 @@
 User-agent: *
 Disallow: /
+
+User-agent: *
+Allow: /knowledge-base.html
+Allow: /knowledge-base/
+
+Sitemap: https://ideav.ru/sitemap.xml

--- a/src/pages/KnowledgeBase.tsx
+++ b/src/pages/KnowledgeBase.tsx
@@ -1,13 +1,81 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { BookOpen, ArrowRight, GitCompare } from 'lucide-react'
+import { BookOpen, ArrowRight, GitCompare, Search, X } from 'lucide-react'
 import { knowledgeBaseArticles } from '../data/knowledgeBase'
 
+const KB_SEO_TITLE = 'База знаний — Интеграм'
+const KB_SEO_DESCRIPTION =
+  'Серия разборов: когда Интеграм удобнее Google Sheets, Excel, Notion, Airtable и других инструментов. Сравнения сценариев, ограничений и отличий.'
+const KB_SEO_KEYWORDS =
+  'база знаний интеграм,сравнение инструментов,интеграм vs airtable,интеграм vs google sheets,интеграм vs excel,no-code база данных,конструктор приложений'
+
+function setMetaTag(selector: string, attr: 'name' | 'property', key: string, content: string) {
+  let el = document.head.querySelector<HTMLMetaElement>(selector)
+  if (!el) {
+    el = document.createElement('meta')
+    el.setAttribute(attr, key)
+    document.head.appendChild(el)
+  }
+  el.setAttribute('content', content)
+}
+
+function setCanonical(href: string) {
+  let el = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+  if (!el) {
+    el = document.createElement('link')
+    el.setAttribute('rel', 'canonical')
+    document.head.appendChild(el)
+  }
+  el.setAttribute('href', href)
+}
+
+function matchesQuery(query: string, article: (typeof knowledgeBaseArticles)[number]): boolean {
+  const q = query.toLowerCase()
+  return (
+    article.title.toLowerCase().includes(q) ||
+    article.shortTitle.toLowerCase().includes(q) ||
+    article.compare.toLowerCase().includes(q) ||
+    article.summary.toLowerCase().includes(q)
+  )
+}
+
 export default function KnowledgeBase() {
+  const [query, setQuery] = useState('')
+
   useEffect(() => {
-    document.title = 'База знаний — Интеграм'
+    document.title = KB_SEO_TITLE
+
+    setMetaTag('meta[name="description"]', 'name', 'description', KB_SEO_DESCRIPTION)
+    setMetaTag('meta[name="keywords"]', 'name', 'keywords', KB_SEO_KEYWORDS)
+    setMetaTag('meta[name="robots"]', 'name', 'robots', 'index, follow')
+
+    setMetaTag('meta[property="og:type"]', 'property', 'og:type', 'website')
+    setMetaTag('meta[property="og:title"]', 'property', 'og:title', KB_SEO_TITLE)
+    setMetaTag('meta[property="og:description"]', 'property', 'og:description', KB_SEO_DESCRIPTION)
+    setMetaTag('meta[property="og:site_name"]', 'property', 'og:site_name', 'Интеграм')
+    setMetaTag('meta[property="og:locale"]', 'property', 'og:locale', 'ru_RU')
+
+    setMetaTag('meta[name="twitter:card"]', 'name', 'twitter:card', 'summary')
+    setMetaTag('meta[name="twitter:title"]', 'name', 'twitter:title', KB_SEO_TITLE)
+    setMetaTag(
+      'meta[name="twitter:description"]',
+      'name',
+      'twitter:description',
+      KB_SEO_DESCRIPTION,
+    )
+
+    const canonicalUrl =
+      typeof window !== 'undefined'
+        ? `${window.location.origin}/knowledge-base.html`
+        : '/knowledge-base.html'
+    setCanonical(canonicalUrl)
   }, [])
+
+  const trimmed = query.trim()
+  const filtered = trimmed
+    ? knowledgeBaseArticles.filter((a) => matchesQuery(trimmed, a))
+    : knowledgeBaseArticles
 
   return (
     <div className="overflow-hidden">
@@ -41,40 +109,72 @@ export default function KnowledgeBase() {
 
       <section className="pb-24">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {knowledgeBaseArticles.map((article, i) => (
-              <motion.div
-                key={article.slug}
-                initial={{ opacity: 0, y: 10 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ delay: Math.min(i * 0.03, 0.3) }}
-              >
-                <Link
-                  to={`/knowledge-base/${article.slug}.html`}
-                  className="group block h-full p-6 rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 hover:border-blue-500/40 hover:shadow-md dark:hover:shadow-none transition-all"
+          <div className="mb-8 max-w-md">
+            <div className="relative">
+              <Search
+                size={16}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 dark:text-slate-500 pointer-events-none"
+              />
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Поиск по базе знаний…"
+                aria-label="Поиск по базе знаний"
+                className="w-full pl-9 pr-9 py-2.5 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 text-sm text-slate-800 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40 transition-all"
+              />
+              {query && (
+                <button
+                  onClick={() => setQuery('')}
+                  aria-label="Очистить поиск"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
                 >
-                  <div className="flex items-center justify-between mb-4">
-                    <span className="text-xs font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">
-                      №&nbsp;{article.number}
-                    </span>
-                    <span className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 dark:text-slate-400">
-                      <GitCompare size={12} /> {article.compare}
-                    </span>
-                  </div>
-                  <h2 className="text-lg font-bold mb-3 leading-snug text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
-                    {article.shortTitle}
-                  </h2>
-                  <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed mb-6">
-                    {article.summary}
-                  </p>
-                  <span className="inline-flex items-center gap-1 text-sm font-semibold text-blue-500 group-hover:gap-2 transition-all">
-                    Читать <ArrowRight size={14} />
-                  </span>
-                </Link>
-              </motion.div>
-            ))}
+                  <X size={14} />
+                </button>
+              )}
+            </div>
           </div>
+
+          {filtered.length === 0 ? (
+            <p className="text-slate-500 dark:text-slate-400 text-sm py-8">
+              По запросу «{trimmed}» статей не найдено.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {filtered.map((article, i) => (
+                <motion.div
+                  key={article.slug}
+                  initial={{ opacity: 0, y: 10 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: Math.min(i * 0.03, 0.3) }}
+                >
+                  <Link
+                    to={`/knowledge-base/${article.slug}.html`}
+                    className="group block h-full p-6 rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 hover:border-blue-500/40 hover:shadow-md dark:hover:shadow-none transition-all"
+                  >
+                    <div className="flex items-center justify-between mb-4">
+                      <span className="text-xs font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">
+                        №&nbsp;{article.number}
+                      </span>
+                      <span className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 dark:text-slate-400">
+                        <GitCompare size={12} /> {article.compare}
+                      </span>
+                    </div>
+                    <h2 className="text-lg font-bold mb-3 leading-snug text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                      {article.shortTitle}
+                    </h2>
+                    <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed mb-6">
+                      {article.summary}
+                    </p>
+                    <span className="inline-flex items-center gap-1 text-sm font-semibold text-blue-500 group-hover:gap-2 transition-all">
+                      Читать <ArrowRight size={14} />
+                    </span>
+                  </Link>
+                </motion.div>
+              ))}
+            </div>
+          )}
         </div>
       </section>
 

--- a/tests/knowledge-base-search-seo.test.mjs
+++ b/tests/knowledge-base-search-seo.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const kbPageSource = readFileSync(
+  new URL('../src/pages/KnowledgeBase.tsx', import.meta.url),
+  'utf8',
+)
+
+const robotsSource = readFileSync(
+  new URL('../public/robots.txt', import.meta.url),
+  'utf8',
+)
+
+test('knowledge base page sets SEO meta title, description and keywords', () => {
+  assert.match(kbPageSource, /KB_SEO_TITLE/)
+  assert.match(kbPageSource, /KB_SEO_DESCRIPTION/)
+  assert.match(kbPageSource, /KB_SEO_KEYWORDS/)
+  assert.match(kbPageSource, /setMetaTag\(/)
+  assert.match(kbPageSource, /'description'/)
+  assert.match(kbPageSource, /'keywords'/)
+  assert.match(kbPageSource, /База знаний — Интеграм/)
+})
+
+test('knowledge base page sets Open Graph and Twitter Card meta tags', () => {
+  assert.match(kbPageSource, /og:title/)
+  assert.match(kbPageSource, /og:description/)
+  assert.match(kbPageSource, /og:type/)
+  assert.match(kbPageSource, /og:site_name/)
+  assert.match(kbPageSource, /og:locale/)
+  assert.match(kbPageSource, /twitter:card/)
+  assert.match(kbPageSource, /twitter:title/)
+  assert.match(kbPageSource, /twitter:description/)
+})
+
+test('knowledge base page sets canonical link', () => {
+  assert.match(kbPageSource, /setCanonical\(/)
+  assert.match(kbPageSource, /knowledge-base\.html/)
+})
+
+test('knowledge base page sets robots meta tag to index, follow', () => {
+  assert.match(kbPageSource, /index, follow/)
+})
+
+test('knowledge base page renders a search input', () => {
+  assert.match(kbPageSource, /type="search"/)
+  assert.match(kbPageSource, /Поиск по базе знаний/)
+  assert.match(kbPageSource, /aria-label="Поиск по базе знаний"/)
+})
+
+test('knowledge base page filters articles by query using matchesQuery', () => {
+  assert.match(kbPageSource, /matchesQuery/)
+  assert.match(kbPageSource, /\.toLowerCase\(\)\.includes\(q\)/)
+})
+
+test('knowledge base page shows empty-state message when search has no results', () => {
+  assert.match(kbPageSource, /не найдено/)
+})
+
+test('knowledge base page shows a clear button when the query is non-empty', () => {
+  assert.match(kbPageSource, /Очистить поиск/)
+  assert.match(kbPageSource, /setQuery\(''\)/)
+})
+
+test('robots.txt allows crawling of knowledge-base routes', () => {
+  assert.match(robotsSource, /Allow: \/knowledge-base\.html/)
+  assert.match(robotsSource, /Allow: \/knowledge-base\//)
+})


### PR DESCRIPTION
## Что сделано

Fixes #196

### Поиск по базе знаний

- На странице `/knowledge-base.html` добавлено поле поиска, которое фильтрует статьи по заголовку, краткому заголовку, сравниваемому инструменту и аннотации.
- При непустом запросе показывается кнопка очистки (×).
- Если ни одна статья не подходит под запрос, выводится сообщение «По запросу «…» статей не найдено.»

### SEO страницы базы знаний

- Динамически устанавливаются мета-теги: `description`, `keywords`, `robots: index, follow`, Open Graph (`og:title`, `og:description`, `og:type`, `og:site_name`, `og:locale`) и Twitter Card.
- Устанавливается канонический URL `/knowledge-base.html`.

### robots.txt

- Добавлены правила `Allow: /knowledge-base.html` и `Allow: /knowledge-base/`, чтобы поисковики могли индексировать базу знаний при общем `Disallow: /`.

### Тесты

Добавлен файл `tests/knowledge-base-search-seo.test.mjs` (9 проверок):
- SEO-мета-теги (title, description, keywords, robots)
- Open Graph и Twitter Card
- Canonical link
- Наличие поля поиска с правильным aria-label
- Логика фильтрации через `matchesQuery`
- Сообщение о пустой выдаче
- Кнопка очистки запроса
- Разрешение crawling в robots.txt

Все 110 тестов проходят (`npm test`).