### PR TITLE
blog-v2: light theme by default + theme toggle + clickable header

### DIFF
--- a/blog-v2/src/components/Header.astro
+++ b/blog-v2/src/components/Header.astro
@@ -56,7 +56,45 @@ const dateStamp = today
           </svg>
           RSS
         </a>
+
+        <button
+          id="theme-toggle"
+          type="button"
+          aria-label="Переключить тему"
+          title="Светлая / тёмная тема"
+          class="inline-flex items-center justify-center w-8 h-8 -mr-2 rounded text-[var(--color-ink-soft)] hover:text-[var(--color-vermilion)] transition-colors"
+        >
+          <svg class="theme-icon-sun" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="4.5"></circle>
+            <path d="M12 2v2.5M12 19.5V22M4.93 4.93l1.77 1.77M17.3 17.3l1.77 1.77M2 12h2.5M19.5 12H22M4.93 19.07l1.77-1.77M17.3 6.7l1.77-1.77"></path>
+          </svg>
+          <svg class="theme-icon-moon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+        </button>
       </nav>
+
+      <style>
+        /* Show the icon for the theme you can switch TO. */
+        :root .theme-icon-sun { display: none; }
+        :root .theme-icon-moon { display: block; }
+        :root[data-theme="dark"] .theme-icon-sun { display: block; }
+        :root[data-theme="dark"] .theme-icon-moon { display: none; }
+      </style>
+
+      <script is:inline>
+        document.getElementById('theme-toggle')?.addEventListener('click', () => {
+          const root = document.documentElement
+          const isDark = root.getAttribute('data-theme') === 'dark'
+          if (isDark) {
+            root.removeAttribute('data-theme')
+            localStorage.setItem('theme', 'light')
+          } else {
+            root.setAttribute('data-theme', 'dark')
+            localStorage.setItem('theme', 'dark')
+          }
+        })
+      </script>
     </div>
 
     <!-- Тагline strip -->
@@ -65,11 +103,11 @@ const dateStamp = today
         Записки о&nbsp;данных, учётных системах и&nbsp;no-code
       </div>
       <div class="hidden sm:flex items-center gap-4 eyebrow text-[var(--color-ink-faint)]">
-        <span>Раздел<span class="text-[var(--color-vermilion)] ml-1.5">платформа</span></span>
+        <a href="/category/o-platforme/" class="link-swipe">Раздел&nbsp;<span class="text-[var(--color-vermilion)]">платформа</span></a>
         <span class="text-[var(--color-hairline-strong)]">/</span>
-        <span>Раздел<span class="text-[var(--color-vermilion)] ml-1.5">технологии</span></span>
+        <a href="/category/tehnologii/" class="link-swipe">Раздел&nbsp;<span class="text-[var(--color-vermilion)]">технологии</span></a>
         <span class="text-[var(--color-hairline-strong)]">/</span>
-        <span>Раздел<span class="text-[var(--color-vermilion)] ml-1.5">обучение</span></span>
+        <a href="/category/obuchenie/" class="link-swipe">Раздел&nbsp;<span class="text-[var(--color-vermilion)]">обучение</span></a>
       </div>
     </div>
   </div>

--- a/blog-v2/src/layouts/BaseLayout.astro
+++ b/blog-v2/src/layouts/BaseLayout.astro
@@ -36,6 +36,18 @@ const imageURL = new URL(image, Astro.site).toString()
     <meta name="generator" content={Astro.generator} />
     <meta name="theme-color" content="#C8392B" />
 
+    <script is:inline>
+      // Apply the saved theme before the body renders to avoid a flash.
+      // Default is light; user can switch to dark via the header toggle.
+      (function () {
+        try {
+          if (localStorage.getItem('theme') === 'dark') {
+            document.documentElement.setAttribute('data-theme', 'dark')
+          }
+        } catch (_) {}
+      })()
+    </script>
+
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />

--- a/blog-v2/src/styles/global.css
+++ b/blog-v2/src/styles/global.css
@@ -20,32 +20,26 @@
   --font-mono: "IBM Plex Mono", "JetBrains Mono", Menlo, monospace;
 }
 
-/* Dark — ink edition */
-@media (prefers-color-scheme: dark) {
-  @theme {
-    --color-paper: oklch(0.14 0.010 65);
-    --color-paper-soft: oklch(0.17 0.012 65);
-    --color-paper-deep: oklch(0.11 0.008 65);
-    --color-ink: oklch(0.93 0.012 85);
-    --color-ink-soft: oklch(0.75 0.014 85);
-    --color-ink-faint: oklch(0.55 0.012 85);
-    --color-hairline: oklch(0.93 0.012 85 / 0.18);
-    --color-hairline-strong: oklch(0.93 0.012 85 / 0.50);
-    --color-vermilion: oklch(0.72 0.18 35);
-    --color-vermilion-deep: oklch(0.82 0.16 38);
-    --color-vermilion-soft: oklch(0.72 0.18 35 / 0.14);
-    --color-warm-gray: oklch(0.65 0.010 85);
-  }
+/* Dark — ink edition. Opt-in via data-theme="dark" on <html>.
+   Default theme is light regardless of the OS prefers-color-scheme. */
+:root[data-theme="dark"] {
+  --color-paper: oklch(0.14 0.010 65);
+  --color-paper-soft: oklch(0.17 0.012 65);
+  --color-paper-deep: oklch(0.11 0.008 65);
+  --color-ink: oklch(0.93 0.012 85);
+  --color-ink-soft: oklch(0.75 0.014 85);
+  --color-ink-faint: oklch(0.55 0.012 85);
+  --color-hairline: oklch(0.93 0.012 85 / 0.18);
+  --color-hairline-strong: oklch(0.93 0.012 85 / 0.50);
+  --color-vermilion: oklch(0.72 0.18 35);
+  --color-vermilion-deep: oklch(0.82 0.16 38);
+  --color-vermilion-soft: oklch(0.72 0.18 35 / 0.14);
+  --color-warm-gray: oklch(0.65 0.010 85);
+  color-scheme: dark;
 }
 
 :root {
-  color-scheme: light dark;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
-  }
+  color-scheme: light;
 }
 
 /* ----- Base ----- */
@@ -75,11 +69,9 @@ body::before {
   mix-blend-mode: multiply;
 }
 
-@media (prefers-color-scheme: dark) {
-  body::before {
-    opacity: 0.18;
-    mix-blend-mode: screen;
-  }
+:root[data-theme="dark"] body::before {
+  opacity: 0.18;
+  mix-blend-mode: screen;
 }
 
 /* Editorial accent bar at the very top of every page */
@@ -260,10 +252,8 @@ body::after {
   font-size: 0.88em;
 }
 
-@media (prefers-color-scheme: dark) {
-  .prose-article code {
-    color: var(--color-vermilion-deep);
-  }
+:root[data-theme="dark"] .prose-article code {
+  color: var(--color-vermilion-deep);
 }
 
 .prose-article pre {


### PR DESCRIPTION
Три маленькие правки в шапке — все по `Header.astro`, поэтому собрал в один PR.

## Что меняется

**Светлая тема по умолчанию.** Раньше тема выбиралась автоматически по системной настройке (`prefers-color-scheme`). Теперь сайт всегда открывается светлым, тёмная тема — опция.

**Переключатель тем в шапке.** Иконка солнца/полумесяца справа от RSS. Показывает иконку той темы, на которую переключит (полумесяц в светлой → клик включает тёмную). Выбор сохраняется в `localStorage`. Inline-скрипт в `<head>` применяет сохранённую тему до отрисовки `<body>` — без вспышки при загрузке.

**«Раздел платформа / технологии / обучение» в шапке стали кликабельными.** Раньше это были декоративные `<span>` — выглядели как ссылки, но никуда не вели. Теперь это `<a>` на соответствующие страницы категорий.

**Фикс «Разделплатформа».** Между «Раздел» и названием категории стоял `<span class="ml-1.5">`, и `margin-left` у inline-элемента в production-сборке не всегда давал видимый пробел. Заменил на `&nbsp;` — визуально то же, работает гарантированно.

## Проверено

Билд: 64 страницы, без ошибок. Pagefind индекс пересобран. Светлая и тёмная темы переключаются корректно. Шапка — со всеми тремя категориями как кликабельные `<a>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)