### PR TITLE
fix(blog-v2): clickable archive cards (nested <a> bug)

### DIFF
--- a/blog-v2/src/pages/category/[slug].astro
+++ b/blog-v2/src/pages/category/[slug].astro
@@ -100,42 +100,39 @@ const allCats = await getAllCategories()
   <section class="max-w-[78rem] mx-auto px-6 lg:px-12 py-14">
     <ol class="border-t border-[var(--color-hairline-strong)]">
       {display.map((post) => (
-        <li class="border-b border-[var(--color-hairline)]">
-          <a
-            href={`/posts/${post.id}/`}
-            class="group block py-7 lg:py-9 transition-colors hover:bg-[var(--color-vermilion-soft)]"
-          >
-            <div class="grid grid-cols-1 lg:grid-cols-12 gap-x-10 px-1">
-              <div class="lg:col-span-2 flex lg:flex-col items-center lg:items-start gap-3 lg:gap-2 mb-4 lg:mb-0">
-                <div class="issue-number text-[var(--color-vermilion)] text-2xl lg:text-3xl font-medium tracking-tight">
-                  №&nbsp;{issueNumberOf.get(post.id)}
-                </div>
-                <div class="eyebrow text-[var(--color-ink-faint)] lg:mt-1">
-                  {formatDate(post.data.pubDate)}
-                </div>
+        <li class="card-container group border-b border-[var(--color-hairline)] py-7 lg:py-9 transition-colors hover:bg-[var(--color-vermilion-soft)]">
+          <div class="grid grid-cols-1 lg:grid-cols-12 gap-x-10 px-1">
+            <div class="lg:col-span-2 flex lg:flex-col items-center lg:items-start gap-3 lg:gap-2 mb-4 lg:mb-0">
+              <div class="issue-number text-[var(--color-vermilion)] text-2xl lg:text-3xl font-medium tracking-tight">
+                №&nbsp;{issueNumberOf.get(post.id)}
               </div>
-              <div class="lg:col-span-7">
-                <h3
-                  class="font-[family-name:var(--font-serif)] text-2xl sm:text-[1.85rem] leading-[1.12] tracking-[-0.012em] text-[var(--color-ink)] group-hover:text-[var(--color-vermilion-deep)] transition-colors"
-                  style="font-variation-settings: 'opsz' 60; font-weight: 600;"
-                >
+              <div class="eyebrow text-[var(--color-ink-faint)] lg:mt-1">
+                {formatDate(post.data.pubDate)}
+              </div>
+            </div>
+            <div class="lg:col-span-7">
+              <h3
+                class="font-[family-name:var(--font-serif)] text-2xl sm:text-[1.85rem] leading-[1.12] tracking-[-0.012em] text-[var(--color-ink)] group-hover:text-[var(--color-vermilion-deep)] transition-colors"
+                style="font-variation-settings: 'opsz' 60; font-weight: 600;"
+              >
+                <a href={`/posts/${post.id}/`} class="card-link">
                   {post.data.title}
-                </h3>
-                <p class="mt-3 text-[var(--color-ink-soft)] max-w-2xl">
-                  {post.data.description}
-                </p>
-              </div>
-              <div class="hidden lg:flex lg:col-span-3 items-start justify-end">
-                <div class="text-right">
-                  <div class="eyebrow text-[var(--color-ink-faint)]">Автор</div>
-                  <div class="mt-1 text-sm text-[var(--color-ink)]">{post.data.author}</div>
-                  <div class="eyebrow text-[var(--color-ink-faint)] mt-3">
-                    {readingTime(post.body ?? '')}&nbsp;мин
-                  </div>
+                </a>
+              </h3>
+              <p class="mt-3 text-[var(--color-ink-soft)] max-w-2xl">
+                {post.data.description}
+              </p>
+            </div>
+            <div class="hidden lg:flex lg:col-span-3 items-start justify-end">
+              <div class="text-right">
+                <div class="eyebrow text-[var(--color-ink-faint)]">Автор</div>
+                <div class="mt-1 text-sm text-[var(--color-ink)]">{post.data.author}</div>
+                <div class="eyebrow text-[var(--color-ink-faint)] mt-3">
+                  {readingTime(post.body ?? '')}&nbsp;мин
                 </div>
               </div>
             </div>
-          </a>
+          </div>
         </li>
       ))}
     </ol>

--- a/blog-v2/src/pages/index.astro
+++ b/blog-v2/src/pages/index.astro
@@ -123,49 +123,45 @@ function readingTime(post: typeof allPosts[number]): number {
 
       <ol class="border-t border-[var(--color-hairline-strong)]">
         {rest.map((post) => (
-          <li class="border-b border-[var(--color-hairline)]">
-            <a
-              href={`/posts/${post.id}/`}
-              class="group block py-7 lg:py-9 transition-colors hover:bg-[var(--color-vermilion-soft)]"
-            >
-              <div class="grid grid-cols-1 lg:grid-cols-12 gap-x-10 px-1">
-                <div class="lg:col-span-2 flex lg:flex-col items-center lg:items-start gap-3 lg:gap-2 mb-4 lg:mb-0">
-                  <div class="issue-number text-[var(--color-vermilion)] text-2xl lg:text-3xl font-medium tracking-tight">
-                    №&nbsp;{post.issueNumber}
-                  </div>
-                  <div class="eyebrow text-[var(--color-ink-faint)] lg:mt-1">
-                    {formatDate(post.data.pubDate)}
-                  </div>
+          <li class="card-container group border-b border-[var(--color-hairline)] py-7 lg:py-9 transition-colors hover:bg-[var(--color-vermilion-soft)]">
+            <div class="grid grid-cols-1 lg:grid-cols-12 gap-x-10 px-1">
+              <div class="lg:col-span-2 flex lg:flex-col items-center lg:items-start gap-3 lg:gap-2 mb-4 lg:mb-0">
+                <div class="issue-number text-[var(--color-vermilion)] text-2xl lg:text-3xl font-medium tracking-tight">
+                  №&nbsp;{post.issueNumber}
                 </div>
-
-                <div class="lg:col-span-7">
-                  <div class="eyebrow text-[var(--color-vermilion)] mb-2 relative z-10">
-                    <a
-                      href={`/category/${categorySlug(post.data.category)}/`}
-                      class="link-swipe pointer-events-auto"
-                      onclick="event.stopPropagation()"
-                    >{post.data.category}</a>
-                  </div>
-                  <h3
-                    class="font-[family-name:var(--font-serif)] text-2xl sm:text-[1.85rem] leading-[1.12] tracking-[-0.012em] text-[var(--color-ink)] group-hover:text-[var(--color-vermilion-deep)] transition-colors"
-                    style="font-variation-settings: 'opsz' 60; font-weight: 600;"
-                  >
-                    {post.data.title}
-                  </h3>
-                  <p class="mt-3 text-[var(--color-ink-soft)] max-w-2xl">
-                    {post.data.description}
-                  </p>
-                </div>
-
-                <div class="hidden lg:flex lg:col-span-3 items-start justify-end">
-                  <div class="text-right">
-                    <div class="eyebrow text-[var(--color-ink-faint)]">Автор</div>
-                    <div class="mt-1 text-sm text-[var(--color-ink)]">{post.data.author}</div>
-                    <div class="eyebrow text-[var(--color-ink-faint)] mt-3">{readingTime(post)}&nbsp;мин</div>
-                  </div>
+                <div class="eyebrow text-[var(--color-ink-faint)] lg:mt-1">
+                  {formatDate(post.data.pubDate)}
                 </div>
               </div>
-            </a>
+
+              <div class="lg:col-span-7">
+                <div class="eyebrow text-[var(--color-vermilion)] mb-2 card-overlay-above">
+                  <a
+                    href={`/category/${categorySlug(post.data.category)}/`}
+                    class="link-swipe"
+                  >{post.data.category}</a>
+                </div>
+                <h3
+                  class="font-[family-name:var(--font-serif)] text-2xl sm:text-[1.85rem] leading-[1.12] tracking-[-0.012em] text-[var(--color-ink)] group-hover:text-[var(--color-vermilion-deep)] transition-colors"
+                  style="font-variation-settings: 'opsz' 60; font-weight: 600;"
+                >
+                  <a href={`/posts/${post.id}/`} class="card-link">
+                    {post.data.title}
+                  </a>
+                </h3>
+                <p class="mt-3 text-[var(--color-ink-soft)] max-w-2xl">
+                  {post.data.description}
+                </p>
+              </div>
+
+              <div class="hidden lg:flex lg:col-span-3 items-start justify-end">
+                <div class="text-right">
+                  <div class="eyebrow text-[var(--color-ink-faint)]">Автор</div>
+                  <div class="mt-1 text-sm text-[var(--color-ink)]">{post.data.author}</div>
+                  <div class="eyebrow text-[var(--color-ink-faint)] mt-3">{readingTime(post)}&nbsp;мин</div>
+                </div>
+              </div>
+            </div>
           </li>
         ))}
       </ol>

--- a/blog-v2/src/pages/tag/[slug].astro
+++ b/blog-v2/src/pages/tag/[slug].astro
@@ -82,45 +82,42 @@ function readingTime(body: string): number {
   <section class="max-w-[78rem] mx-auto px-6 lg:px-12 py-14">
     <ol class="border-t border-[var(--color-hairline-strong)]">
       {display.map((post) => (
-        <li class="border-b border-[var(--color-hairline)]">
-          <a
-            href={`/posts/${post.id}/`}
-            class="group block py-7 lg:py-9 transition-colors hover:bg-[var(--color-vermilion-soft)]"
-          >
-            <div class="grid grid-cols-1 lg:grid-cols-12 gap-x-10 px-1">
-              <div class="lg:col-span-2 flex lg:flex-col items-center lg:items-start gap-3 lg:gap-2 mb-4 lg:mb-0">
-                <div class="issue-number text-[var(--color-vermilion)] text-2xl lg:text-3xl font-medium tracking-tight">
-                  №&nbsp;{issueNumberOf.get(post.id)}
-                </div>
-                <div class="eyebrow text-[var(--color-ink-faint)] lg:mt-1">
-                  {formatDate(post.data.pubDate)}
-                </div>
+        <li class="card-container group border-b border-[var(--color-hairline)] py-7 lg:py-9 transition-colors hover:bg-[var(--color-vermilion-soft)]">
+          <div class="grid grid-cols-1 lg:grid-cols-12 gap-x-10 px-1">
+            <div class="lg:col-span-2 flex lg:flex-col items-center lg:items-start gap-3 lg:gap-2 mb-4 lg:mb-0">
+              <div class="issue-number text-[var(--color-vermilion)] text-2xl lg:text-3xl font-medium tracking-tight">
+                №&nbsp;{issueNumberOf.get(post.id)}
               </div>
-              <div class="lg:col-span-7">
-                <div class="eyebrow text-[var(--color-vermilion)] mb-2 relative z-10">
-                  <a href={`/category/${categorySlug(post.data.category)}/`} class="link-swipe pointer-events-auto" onclick="event.stopPropagation()">{post.data.category}</a>
-                </div>
-                <h3
-                  class="font-[family-name:var(--font-serif)] text-2xl sm:text-[1.85rem] leading-[1.12] tracking-[-0.012em] text-[var(--color-ink)] group-hover:text-[var(--color-vermilion-deep)] transition-colors"
-                  style="font-variation-settings: 'opsz' 60; font-weight: 600;"
-                >
+              <div class="eyebrow text-[var(--color-ink-faint)] lg:mt-1">
+                {formatDate(post.data.pubDate)}
+              </div>
+            </div>
+            <div class="lg:col-span-7">
+              <div class="eyebrow text-[var(--color-vermilion)] mb-2 card-overlay-above">
+                <a href={`/category/${categorySlug(post.data.category)}/`} class="link-swipe">{post.data.category}</a>
+              </div>
+              <h3
+                class="font-[family-name:var(--font-serif)] text-2xl sm:text-[1.85rem] leading-[1.12] tracking-[-0.012em] text-[var(--color-ink)] group-hover:text-[var(--color-vermilion-deep)] transition-colors"
+                style="font-variation-settings: 'opsz' 60; font-weight: 600;"
+              >
+                <a href={`/posts/${post.id}/`} class="card-link">
                   {post.data.title}
-                </h3>
-                <p class="mt-3 text-[var(--color-ink-soft)] max-w-2xl">
-                  {post.data.description}
-                </p>
-              </div>
-              <div class="hidden lg:flex lg:col-span-3 items-start justify-end">
-                <div class="text-right">
-                  <div class="eyebrow text-[var(--color-ink-faint)]">Автор</div>
-                  <div class="mt-1 text-sm text-[var(--color-ink)]">{post.data.author}</div>
-                  <div class="eyebrow text-[var(--color-ink-faint)] mt-3">
-                    {readingTime(post.body ?? '')}&nbsp;мин
-                  </div>
+                </a>
+              </h3>
+              <p class="mt-3 text-[var(--color-ink-soft)] max-w-2xl">
+                {post.data.description}
+              </p>
+            </div>
+            <div class="hidden lg:flex lg:col-span-3 items-start justify-end">
+              <div class="text-right">
+                <div class="eyebrow text-[var(--color-ink-faint)]">Автор</div>
+                <div class="mt-1 text-sm text-[var(--color-ink)]">{post.data.author}</div>
+                <div class="eyebrow text-[var(--color-ink-faint)] mt-3">
+                  {readingTime(post.body ?? '')}&nbsp;мин
                 </div>
               </div>
             </div>
-          </a>
+          </div>
         </li>
       ))}
     </ol>

--- a/blog-v2/src/styles/global.css
+++ b/blog-v2/src/styles/global.css
@@ -114,6 +114,28 @@ body::after {
   font-variation-settings: "opsz" 14;
 }
 
+/* Overlay-link pattern for archive cards.
+   Apply to <a> inside a heading; its ::before extends to cover the
+   nearest .card-container ancestor, so the whole row becomes clickable
+   while inner links (category, tags) stay independent.
+   Avoids the nested-<a> bug that ate the title in the previous markup. */
+.card-link::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+.card-link {
+  position: static;
+}
+.card-container {
+  position: relative;
+}
+.card-container .card-overlay-above {
+  position: relative;
+  z-index: 2;
+}
+
 /* Hairline link underline that swipes from left on hover */
 .link-swipe {
   position: relative;


### PR DESCRIPTION
Closes #221.

В архивных карточках строки были обёрнуты в `<a href="/posts/...">`, а внутри ещё `<a href="/category/...">`. Вложенные `<a>` — невалидный HTML, браузер закрывает внешний на месте внутреннего. Из-за этого:
- Колонки до категории (№ выпуска и дата) становились «пустыми кликабельными div'ами» (тот самый скриншот).
- Заголовок и описание выпадали из ссылки совсем — клик по ним ничего не делал.

Поменял на стандартный overlay-link паттерн: ссылка на статью висит на `<h3>` и через `::before` накрывает всю карточку. Ссылка категории получает выше z-index. Без `pointer-events` и `stopPropagation`.

Применил на всех трёх архивах: главная, страница тега, страница категории. Build чистый.

🤖 Generated with [Claude Code](https://claude.com/claude-code)