### PR TITLE
style(blog-v2): shrink article H2 by ~26%

### DIFF
--- a/blog-v2/src/styles/global.css
+++ b/blog-v2/src/styles/global.css
@@ -189,18 +189,18 @@ body::after {
   font-family: var(--font-serif);
   font-weight: 600;
   font-variation-settings: "opsz" 60;
-  font-size: 1.55rem;
-  line-height: 1.18;
-  letter-spacing: -0.012em;
-  margin-top: 2.8rem;
-  margin-bottom: 1rem;
+  font-size: 1.15rem;
+  line-height: 1.25;
+  letter-spacing: -0.008em;
+  margin-top: 2.2rem;
+  margin-bottom: 0.75rem;
   color: var(--color-ink);
 }
 
 .prose-article h2::before {
   content: "§";
   display: inline-block;
-  margin-right: 0.55rem;
+  margin-right: 0.45rem;
   color: var(--color-vermilion);
   font-weight: 500;
   font-variation-settings: "opsz" 30;


### PR DESCRIPTION
В теле статьи H2 был слишком крупным (1.55rem) и зрительно конкурировал с заголовком статьи. Уменьшил до 1.15rem (≈ −26%), пропорционально подтянул line-height и верхний отступ, чтобы блок не выглядел разболтанным.

Только метрики H2 — h3, размер тела, маркеры списков, цвет § остаются как были.

🤖 Generated with [Claude Code](https://claude.com/claude-code)