### PR TITLE
style(blog-v2): shrink home-page H2s by ~25%

### DIFF
--- a/blog-v2/src/pages/index.astro
+++ b/blog-v2/src/pages/index.astro
@@ -82,7 +82,7 @@ function readingTime(post: typeof allPosts[number]): number {
         <div class="lg:col-span-10">
           <a href={`/posts/${featured.id}/`} class="group block">
             <h2
-              class="font-[family-name:var(--font-serif)] text-[2rem] sm:text-[3rem] lg:text-[3.6rem] leading-[1.02] tracking-[-0.022em] text-[var(--color-ink)] group-hover:text-[var(--color-vermilion)] transition-colors"
+              class="font-[family-name:var(--font-serif)] text-[1.5rem] sm:text-[2.25rem] lg:text-[2.7rem] leading-[1.05] tracking-[-0.02em] text-[var(--color-ink)] group-hover:text-[var(--color-vermilion)] transition-colors"
               style="font-variation-settings: 'opsz' 144, 'SOFT' 30; font-weight: 500;"
             >
               {featured.data.title}
@@ -113,7 +113,7 @@ function readingTime(post: typeof allPosts[number]): number {
         </div>
         <div class="lg:col-span-10">
           <h2
-            class="font-[family-name:var(--font-serif)] text-3xl sm:text-4xl tracking-[-0.012em] text-[var(--color-ink)]"
+            class="font-[family-name:var(--font-serif)] text-2xl sm:text-3xl tracking-[-0.012em] text-[var(--color-ink)]"
             style="font-variation-settings: 'opsz' 144, 'SOFT' 30; font-weight: 500;"
           >
             Архив <span class="italic font-normal text-[var(--color-vermilion)]">выпусков</span>


### PR DESCRIPTION
Продолжение PR #225 (там был H2 в теле статьи). Тут — два H2 на главной:

- **Featured-блок «Свежий выпуск»** — заголовок статьи: `2/3/3.6rem → 1.5/2.25/2.7rem` (≈ −25%).
- **«Архив выпусков»** — заголовок раздела: `text-3xl/4xl → text-2xl/3xl`.

Масштабный H1-масштхед в начале страницы намеренно оставил большим — это якорь визуальной идентичности страницы. Уменьшаются только H2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)