### PR TITLE
fix(kb): intro points at real product work, not at the content plan

### DIFF
--- a/src/pages/KnowledgeBase.tsx
+++ b/src/pages/KnowledgeBase.tsx
@@ -154,14 +154,15 @@ export default function KnowledgeBase() {
               Серия разборов сценариев, в которых Интеграм заменяет или дополняет
               распространённые инструменты — от Google Sheets до заказной разработки.
               Каждая статья описывает контекст, что Интеграм делает иначе, и где у него
-              есть ограничения. Тексты основаны на{' '}
+              есть ограничения. Примеры взяты из ежедневной работы над платформой —
+              правки дашбордов, отчётов, шаблонов и форм. Журнал этой работы открыт:{' '}
               <a
-                href="https://github.com/ideav/crm/tree/main/docs/integram-article-reviews"
+                href="https://github.com/ideav/crm/issues?q=is%3Aissue+state%3Aclosed+html"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline hover:text-blue-500 dark:hover:text-blue-400"
               >
-                открытом плане серии обзоров
+                закрытые задачи в&nbsp;репозитории продукта
               </a>
               .
             </p>


### PR DESCRIPTION
Подпись в шапке базы знаний раньше говорила «Тексты основаны на открытом плане серии обзоров» со ссылкой на папку с редакционным планом. Это звучало как мета-обещание про **производство самих статей** — что не интересно читателю, пришедшему про продукт.

Заменил на отсылку к **реальной работе над продуктом**, которую эти статьи описывают: ежедневные правки дашбордов, отчётов, шаблонов и форм в репозитории Интеграма. Ссылка теперь ведёт на [закрытые задачи в ideav/crm с тегом html](https://github.com/ideav/crm/issues?q=is%3Aissue+state%3Aclosed+html) — то, что верифицируется кодом.

```
до:    Тексты основаны на [открытом плане серии обзоров → docs/].
после: Примеры взяты из ежедневной работы над платформой —
       правки дашбордов, отчётов, шаблонов и форм. Журнал этой
       работы открыт: [закрытые задачи в репозитории продукта →
       ideav/crm/issues].
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)