### PR TITLE
feat(kb): per-article prerender + JSON-LD + OG/Twitter + canonical

### DIFF
--- a/scripts/prerender-knowledge-base.mjs
+++ b/scripts/prerender-knowledge-base.mjs
@@ -1,30 +1,47 @@
 #!/usr/bin/env node
 /**
- * Post-build prerender for /knowledge-base.html.
+ * Post-build prerender for the Knowledge Base.
  *
- * Reads the SPA template `dist/index.html` and writes a copy at
- * `dist/knowledge-base.html` whose `<div id="root">` is populated with
- * a fully-rendered HTML listing of all KB articles, grouped by theme,
- * with introductory copy and a "last updated" stamp.
+ * For each crawler-relevant URL we drop a fully-rendered HTML file
+ * next to the SPA bundle. When a real visitor opens the URL:
  *
- * When a real visitor opens the URL:
  *   - The HTTP response carries this static HTML, so search engines,
- *     LLM crawlers, and no-JS clients see the full list.
- *   - When React boots, `createRoot().render(<App/>)` replaces the
+ *     LLM crawlers (GPT-Bot, ClaudeBot, PerplexityBot, …) and no-JS
+ *     clients see meaningful content right away. Social-preview bots
+ *     (Telegram, VK, Twitter) pick up OG/Twitter tags too.
+ *   - When React boots, createRoot().render(<App/>) replaces the
  *     contents of #root with the SPA — the static fallback disappears.
+ *
+ * Generates:
+ *   dist/knowledge-base.html              — collection page (16+ groups)
+ *   dist/knowledge-base/index.html        — same, served at the no-suffix URL
+ *   dist/knowledge-base/<slug>/index.html — one per article
+ *
+ * Each file gets:
+ *   - tightened <title>
+ *   - per-page meta description and keywords
+ *   - <link rel="canonical">
+ *   - Open Graph + Twitter Card tags (for Telegram/VK/Twitter previews)
+ *   - JSON-LD structured data (CollectionPage + ItemList on the index,
+ *     Article on each post)
  *
  * Articles are loaded from src/data/knowledgeBase.ts via esbuild so we
  * don't have to maintain a parallel JSON.
  */
-import { readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { build } from 'esbuild'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '..')
+const dist = resolve(root, 'dist')
+const SITE = 'https://ideav.ru'
+const PUBLISHER = 'Интеграм'
 
-// --- Load article data via a temporary ESM bundle -------------------------
+// ───────────────────────────────────────────────────────────────────────────
+//  Load article data
+// ───────────────────────────────────────────────────────────────────────────
 const bundleResult = await build({
   entryPoints: [resolve(root, 'src/data/knowledgeBase.ts')],
   bundle: true,
@@ -40,8 +57,9 @@ const dataUrl =
   Buffer.from(bundleResult.outputFiles[0].text).toString('base64')
 const { knowledgeBaseArticles } = await import(dataUrl)
 
-// --- Group definitions ----------------------------------------------------
-// Manual but explicit: it's clearer than trying to infer from tags.
+// ───────────────────────────────────────────────────────────────────────────
+//  Groups for the index page
+// ───────────────────────────────────────────────────────────────────────────
 const groups = [
   {
     title: 'Замена Excel и Google Sheets',
@@ -92,21 +110,11 @@ const groups = [
   },
 ]
 
-// --- Build HTML ------------------------------------------------------------
-const articlesBySlug = new Map(knowledgeBaseArticles.map((a) => [a.slug, a]))
-const groupedSlugs = new Set(groups.flatMap((g) => g.slugs))
-const orphan = knowledgeBaseArticles.filter((a) => !groupedSlugs.has(a.slug))
-if (orphan.length > 0) {
-  // Catch-all so nothing is silently dropped.
-  groups.push({
-    title: 'Остальные материалы',
-    blurb: '',
-    slugs: orphan.map((a) => a.slug),
-  })
-}
-
+// ───────────────────────────────────────────────────────────────────────────
+//  Helpers
+// ───────────────────────────────────────────────────────────────────────────
 function escape(s) {
-  return String(s).replace(/[&<>"']/g, (c) => ({
+  return String(s ?? '').replace(/[&<>"']/g, (c) => ({
     '&': '&amp;',
     '<': '&lt;',
     '>': '&gt;',
@@ -115,14 +123,77 @@ function escape(s) {
   }[c]))
 }
 
+function trim(text, max = 230) {
+  const t = String(text ?? '').replace(/\s+/g, ' ').trim()
+  if (t.length <= max) return t
+  return t.slice(0, max).replace(/\s+\S*$/, '') + '…'
+}
+
 const today = new Date().toLocaleDateString('ru-RU', {
   day: 'numeric',
   month: 'long',
   year: 'numeric',
 }).replace(' г.', '')
+const todayISO = new Date().toISOString().slice(0, 10)
 
+const articlesBySlug = new Map(knowledgeBaseArticles.map((a) => [a.slug, a]))
+const groupedSlugs = new Set(groups.flatMap((g) => g.slugs))
+const orphan = knowledgeBaseArticles.filter((a) => !groupedSlugs.has(a.slug))
+if (orphan.length > 0) {
+  groups.push({
+    title: 'Остальные материалы',
+    blurb: '',
+    slugs: orphan.map((a) => a.slug),
+  })
+}
 const totalCount = knowledgeBaseArticles.length
+const distIndex = readFileSync(resolve(dist, 'index.html'), 'utf8')
 
+// ───────────────────────────────────────────────────────────────────────────
+//  Common <head> patching
+// ───────────────────────────────────────────────────────────────────────────
+/**
+ * Patch the SPA template with per-page <title>, description, canonical,
+ * Open Graph / Twitter / JSON-LD, and the prerendered #root body.
+ */
+function patchHtml({ title, description, canonical, ogType, jsonLd, bodyHtml, keywords }) {
+  const ogDesc = trim(description, 300)
+  const tags = [
+    `<link rel="canonical" href="${escape(canonical)}" />`,
+    `<meta name="og:image" content="${SITE}/logos/integram-og.png" />`.replace('name=', 'property='),
+    `<meta property="og:type" content="${escape(ogType)}" />`,
+    `<meta property="og:url" content="${escape(canonical)}" />`,
+    `<meta property="og:title" content="${escape(title)}" />`,
+    `<meta property="og:description" content="${escape(ogDesc)}" />`,
+    `<meta property="og:locale" content="ru_RU" />`,
+    `<meta property="og:site_name" content="${PUBLISHER}" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${escape(title)}" />`,
+    `<meta name="twitter:description" content="${escape(ogDesc)}" />`,
+    `<script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>`,
+  ].join('\n    ')
+
+  let html = distIndex
+    .replace(/<title>[^<]*<\/title>/, `<title>${escape(title)}</title>`)
+    .replace(
+      /<meta name="description" content="[^"]*"\s*\/>/,
+      `<meta name="description" content="${escape(description)}" />`
+    )
+    .replace(
+      /<meta name="keywords" content="[^"]*"\s*\/>/,
+      keywords
+        ? `<meta name="keywords" content="${escape(keywords)}" />`
+        : ''
+    )
+    .replace('</head>', `    ${tags}\n  </head>`)
+    .replace('<div id="root"></div>', `<div id="root">${bodyHtml}</div>`)
+
+  return html
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Index page (collection)
+// ───────────────────────────────────────────────────────────────────────────
 const groupsHtml = groups
   .filter((g) => g.slugs.length > 0)
   .map((g) => {
@@ -134,7 +205,7 @@ const groupsHtml = groups
           <li class="kb-prerender__item">
             <a href="/knowledge-base/${escape(a.slug)}">
               <h3>${escape(a.shortTitle || a.title)}</h3>
-              <p>${escape(a.compare || a.summary?.slice(0, 220) || '')}</p>
+              <p>${escape(a.compare || trim(a.summary, 220))}</p>
             </a>
           </li>`
       )
@@ -148,7 +219,7 @@ const groupsHtml = groups
   })
   .join('')
 
-const prerenderHtml = `
+const indexBody = `
 <article id="kb-prerender" itemscope itemtype="https://schema.org/CollectionPage">
   <header>
     <p class="kb-prerender__eyebrow">База знаний · ${totalCount} разборов</p>
@@ -171,62 +242,187 @@ const prerenderHtml = `
   </footer>
 </article>
 <style>
-  #kb-prerender {
-    max-width: 64rem;
-    margin: 0 auto;
-    padding: 4rem 1rem 2rem;
-    font-family: ui-sans-serif, system-ui, sans-serif;
-    color: #1e293b;
-  }
+  #kb-prerender { max-width: 64rem; margin: 0 auto; padding: 4rem 1rem 2rem;
+    font-family: ui-sans-serif, system-ui, sans-serif; color: #1e293b; }
   #kb-prerender h1 { font-size: 2.4rem; line-height: 1.1; margin: 0.5rem 0 1rem; }
   #kb-prerender h2 { font-size: 1.35rem; margin: 2.5rem 0 0.5rem; }
   #kb-prerender h3 { font-size: 1.05rem; margin: 0 0 0.4rem; font-weight: 600; }
   #kb-prerender p  { line-height: 1.55; margin: 0.5rem 0; }
-  #kb-prerender .kb-prerender__eyebrow {
-    text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.72rem;
-    color: #3b82f6; font-weight: 700; margin: 0;
-  }
+  #kb-prerender .kb-prerender__eyebrow { text-transform: uppercase; letter-spacing: 0.1em;
+    font-size: 0.72rem; color: #3b82f6; font-weight: 700; margin: 0; }
   #kb-prerender .kb-prerender__lead { font-size: 1.1rem; color: #475569; max-width: 48rem; }
   #kb-prerender .kb-prerender__updated { font-size: 0.78rem; color: #64748b; margin-top: 1rem; }
   #kb-prerender .kb-prerender__count { font-weight: 400; color: #64748b; font-size: 0.85em; }
   #kb-prerender .kb-prerender__blurb { color: #475569; max-width: 48rem; margin-bottom: 1rem; }
   #kb-prerender .kb-prerender__list { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.5rem; }
-  #kb-prerender .kb-prerender__item a {
-    display: block; padding: 0.9rem 1rem;
-    border: 1px solid #e2e8f0; border-radius: 0.5rem;
-    color: inherit; text-decoration: none;
-  }
+  #kb-prerender .kb-prerender__item a { display: block; padding: 0.9rem 1rem;
+    border: 1px solid #e2e8f0; border-radius: 0.5rem; color: inherit; text-decoration: none; }
   #kb-prerender .kb-prerender__item a:hover { border-color: #3b82f6; }
   #kb-prerender .kb-prerender__item p { font-size: 0.92rem; color: #475569; margin: 0; }
-  #kb-prerender .kb-prerender__footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e2e8f0; font-size: 0.92rem; color: #475569; }
+  #kb-prerender .kb-prerender__footer { margin-top: 3rem; padding-top: 1.5rem;
+    border-top: 1px solid #e2e8f0; font-size: 0.92rem; color: #475569; }
   @media (prefers-color-scheme: dark) {
     #kb-prerender { color: #e2e8f0; }
-    #kb-prerender .kb-prerender__lead,
-    #kb-prerender .kb-prerender__blurb,
-    #kb-prerender .kb-prerender__item p,
-    #kb-prerender .kb-prerender__footer { color: #94a3b8; }
+    #kb-prerender .kb-prerender__lead, #kb-prerender .kb-prerender__blurb,
+    #kb-prerender .kb-prerender__item p, #kb-prerender .kb-prerender__footer { color: #94a3b8; }
     #kb-prerender .kb-prerender__item a { border-color: #1e293b; }
-    #kb-prerender .kb-prerender__count,
-    #kb-prerender .kb-prerender__updated { color: #94a3b8; }
+    #kb-prerender .kb-prerender__count, #kb-prerender .kb-prerender__updated { color: #94a3b8; }
   }
 </style>`
 
-// --- Patch dist/index.html into dist/knowledge-base.html ------------------
-const distIndex = readFileSync(resolve(root, 'dist/index.html'), 'utf8')
-const distKb = distIndex.replace(
-  '<div id="root"></div>',
-  `<div id="root">${prerenderHtml}</div>`
-)
-// Also tighten the title and description for this specific page.
-const distKbWithMeta = distKb
-  .replace(
-    /<title>[^<]*<\/title>/,
-    `<title>База знаний — ${totalCount} разборов сравнений Интеграма с Excel, Airtable, Notion и заказной разработкой</title>`
-  )
-  .replace(
-    /<meta name="description" content="[^"]*"\s*\/>/,
-    `<meta name="description" content="${totalCount} статей о том, в каких сценариях Интеграм заменяет Excel, Google Sheets, Airtable, Notion и заказную разработку. Группировка по темам, описание контекста каждой статьи, дата последнего обновления." />`
-  )
+const indexTitle = `База знаний — ${totalCount} разборов сравнений Интеграма с Excel, Airtable, Notion и заказной разработкой`
+const indexDescription = `${totalCount} статей о том, в каких сценариях Интеграм заменяет Excel, Google Sheets, Airtable, Notion и заказную разработку. Группировка по темам, описание контекста каждой статьи, дата последнего обновления.`
 
-writeFileSync(resolve(root, 'dist/knowledge-base.html'), distKbWithMeta)
-console.log(`✓ wrote dist/knowledge-base.html (${distKbWithMeta.length} bytes, ${totalCount} articles)`)
+const collectionJsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'CollectionPage',
+      '@id': `${SITE}/knowledge-base#collection`,
+      url: `${SITE}/knowledge-base`,
+      name: indexTitle,
+      description: indexDescription,
+      inLanguage: 'ru',
+      isPartOf: { '@type': 'WebSite', name: PUBLISHER, url: SITE },
+      dateModified: todayISO,
+    },
+    {
+      '@type': 'ItemList',
+      '@id': `${SITE}/knowledge-base#articles`,
+      numberOfItems: totalCount,
+      itemListElement: knowledgeBaseArticles.map((a, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        url: `${SITE}/knowledge-base/${a.slug}`,
+        name: a.shortTitle || a.title,
+      })),
+    },
+  ],
+}
+
+const indexHtml = patchHtml({
+  title: indexTitle,
+  description: indexDescription,
+  canonical: `${SITE}/knowledge-base`,
+  ogType: 'website',
+  jsonLd: collectionJsonLd,
+  bodyHtml: indexBody,
+  keywords:
+    'интеграм, no-code, замена excel, аналог airtable, альтернатива notion, заказная разработка, конструктор баз данных',
+})
+
+writeFileSync(resolve(dist, 'knowledge-base.html'), indexHtml)
+mkdirSync(resolve(dist, 'knowledge-base'), { recursive: true })
+writeFileSync(resolve(dist, 'knowledge-base/index.html'), indexHtml)
+console.log(`✓ /knowledge-base{,.html}/index.html  (${indexHtml.length} bytes, ${totalCount} articles)`)
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Per-article pages
+// ───────────────────────────────────────────────────────────────────────────
+for (const article of knowledgeBaseArticles) {
+  const url = `${SITE}/knowledge-base/${article.slug}`
+  const title = article.seoTitle || article.title
+  const description = article.metaDescription || article.seoDescription || trim(article.summary, 260)
+  const ogTitle = article.ogTitle || title
+  const ogDescription = article.ogDescription || description
+  const keywords = article.metaKeywords || ''
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    '@id': `${url}#article`,
+    headline: title,
+    name: article.title,
+    description,
+    url,
+    inLanguage: 'ru',
+    dateModified: todayISO,
+    author: { '@type': 'Organization', name: PUBLISHER, url: SITE },
+    publisher: {
+      '@type': 'Organization',
+      name: PUBLISHER,
+      url: SITE,
+      logo: { '@type': 'ImageObject', url: `${SITE}/logos/integram-og.png` },
+    },
+    isPartOf: {
+      '@type': 'CollectionPage',
+      name: 'База знаний',
+      url: `${SITE}/knowledge-base`,
+    },
+    mainEntityOfPage: url,
+  }
+
+  const contextHtml = article.context
+    ? `<section class="kb-article__context"><p>${escape(article.context)}</p></section>`
+    : ''
+
+  const scenarioHtml = article.scenario?.symptoms?.length
+    ? `<section class="kb-article__scenario">
+        <h2>Контекст</h2>
+        ${article.scenario.intro ? `<p>${escape(article.scenario.intro)}</p>` : ''}
+        <ul>${article.scenario.symptoms.map((s) => `<li>${escape(s)}</li>`).join('')}</ul>
+      </section>`
+    : ''
+
+  const integramHtml = article.integramScenario?.steps?.length
+    ? `<section class="kb-article__integram">
+        <h2>Как это решает Интеграм</h2>
+        ${article.integramScenario.intro ? `<p>${escape(article.integramScenario.intro)}</p>` : ''}
+        <ol>${article.integramScenario.steps.map((s) => `<li>${escape(s)}</li>`).join('')}</ol>
+      </section>`
+    : ''
+
+  const articleBody = `
+<article id="kb-prerender" itemscope itemtype="https://schema.org/TechArticle">
+  <nav class="kb-article__nav"><a href="/knowledge-base">← База знаний</a></nav>
+  <header>
+    <p class="kb-prerender__eyebrow">Статья ${escape(article.number || article.slug)}</p>
+    <h1 itemprop="headline">${escape(article.title)}</h1>
+    <p class="kb-prerender__lead" itemprop="description">${escape(article.compare || trim(article.summary, 220))}</p>
+  </header>
+  <section class="kb-article__summary"><p>${escape(article.summary)}</p></section>
+  ${contextHtml}
+  ${scenarioHtml}
+  ${integramHtml}
+  <footer class="kb-prerender__footer">
+    <a href="/knowledge-base">← Все статьи базы знаний</a>
+  </footer>
+</article>
+<style>
+  #kb-prerender { max-width: 48rem; margin: 0 auto; padding: 4rem 1rem 2rem;
+    font-family: ui-sans-serif, system-ui, sans-serif; color: #1e293b; line-height: 1.6; }
+  #kb-prerender h1 { font-size: 2rem; line-height: 1.15; margin: 0.4rem 0 1rem; }
+  #kb-prerender h2 { font-size: 1.25rem; margin: 2rem 0 0.5rem; }
+  #kb-prerender p  { margin: 0.6rem 0; }
+  #kb-prerender .kb-article__nav { margin-bottom: 1.5rem; font-size: 0.92rem; }
+  #kb-prerender .kb-article__nav a { color: #3b82f6; text-decoration: none; }
+  #kb-prerender .kb-prerender__eyebrow { text-transform: uppercase; letter-spacing: 0.1em;
+    font-size: 0.72rem; color: #3b82f6; font-weight: 700; margin: 0; }
+  #kb-prerender .kb-prerender__lead { font-size: 1.15rem; color: #334155; margin: 0.8rem 0 1.5rem; }
+  #kb-prerender ul, #kb-prerender ol { padding-left: 1.5rem; }
+  #kb-prerender li { margin-bottom: 0.4rem; }
+  #kb-prerender .kb-prerender__footer { margin-top: 3rem; padding-top: 1.5rem;
+    border-top: 1px solid #e2e8f0; font-size: 0.92rem; }
+  @media (prefers-color-scheme: dark) {
+    #kb-prerender { color: #e2e8f0; }
+    #kb-prerender .kb-prerender__lead { color: #cbd5e1; }
+    #kb-prerender .kb-prerender__footer { border-color: #1e293b; }
+  }
+</style>`
+
+  const html = patchHtml({
+    title,
+    description: trim(description, 300),
+    canonical: url,
+    ogType: 'article',
+    jsonLd,
+    bodyHtml: articleBody,
+    keywords,
+  })
+
+  const dir = resolve(dist, 'knowledge-base', article.slug)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(resolve(dir, 'index.html'), html)
+}
+
+console.log(`✓ ${knowledgeBaseArticles.length} article pages → dist/knowledge-base/<slug>/index.html`)


### PR DESCRIPTION
Вторая итерация поверх PR #229. Закрывает SEO-пункты, которых не было в issue #227, но без них prerender работал бы только наполовину.

## Что добавляется

**JSON-LD структурированные данные**
- На `/knowledge-base` — `CollectionPage` + `ItemList` (20 позиций со ссылками на каждую статью). Это даёт rich-result eligibility в Google и улучшает извлечение каталога LLM-краулерами.
- На каждой статье — `TechArticle` с headline, description, author, publisher, dateModified, canonical URL.

**Open Graph + Twitter Card**
На каждом URL: `og:type`, `og:url`, `og:title`, `og:description`, `og:image`, `og:locale`, `og:site_name`, плюс Twitter Card. Telegram/VK/Twitter теперь будут показывать осмысленные превью при шеринге ссылок (раньше для SPA-страницы — никаких).

**`<link rel="canonical">`** на каждой странице. Чистый сигнал поисковикам, и страховка под кросс-публикацию (например, версия статьи на Habr может ставить canonical → ideav.ru, чтобы не получить дубль).

**Prerender для каждой статьи**
До этого PR `/knowledge-base/<slug>` отдавал ту же пустую SPA-оболочку, что и каталог до PR #229. Теперь каждая из 20 статей получает свой статический HTML с:
- собственными `<title>` (seoTitle), `<meta name="description">` (metaDescription), `keywords` из данных статьи;
- заголовком, лидом (`compare`), сводкой (`summary`);
- блоками «Контекст» и «Как это решает Интеграм» (если они есть в данных).

## Что строится

После `npm run build`:
```
dist/knowledge-base.html               ← каталог
dist/knowledge-base/index.html         ← каталог без .html
dist/knowledge-base/<slug>/index.html  ← одна на статью, ×20
```

Apache сам отдаст эти статические файлы (физический файл идёт раньше SPA-fallback). React при загрузке заменит `#root` на SPA — пользователь видит привычный UI, поисковики и LLM получают полный контент.

🤖 Generated with [Claude Code](https://claude.com/claude-code)