### PR TITLE
fix(kb): «выполненные задачи» вместо «закрытые задачи»

### DIFF
--- a/src/pages/KnowledgeBase.tsx
+++ b/src/pages/KnowledgeBase.tsx
@@ -162,7 +162,7 @@ export default function KnowledgeBase() {
                 rel="noopener noreferrer"
                 className="underline hover:text-blue-500 dark:hover:text-blue-400"
               >
-                закрытые задачи в&nbsp;репозитории продукта
+                выполненные задачи в&nbsp;репозитории продукта
               </a>
               .
             </p>


### PR DESCRIPTION
Косметика во вводном абзаце базы знаний.

Было: «Журнал этой работы открыт: **закрытые** задачи в репозитории продукта».
Стало: «Журнал этой работы открыт: **выполненные** задачи в репозитории продукта».

Ссылка ведёт туда же — `?q=is:issue state:closed html`. Просто убирает стилистическое «открыт: закрытые».

🤖 Generated with [Claude Code](https://claude.com/claude-code)