### PR TITLE
style(kb): remove article numbers from UI

### DIFF
--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -242,7 +242,7 @@ console.log(`✓ public/og/knowledge-base.png`)
 for (const article of knowledgeBaseArticles) {
   const eyebrow = article.compare
     ? `Сравнение с ${article.compare}`
-    : `Статья ${article.number || article.slug}`
+    : 'База знаний'
   const raw = (article.metaDescription || article.summary || '').replace(/\s+/g, ' ').trim()
   const subtitle = raw.length > 170 ? raw.slice(0, 167).replace(/\s+\S*$/, '') + '…' : raw
   await render(

--- a/scripts/prerender-knowledge-base.mjs
+++ b/scripts/prerender-knowledge-base.mjs
@@ -381,7 +381,7 @@ for (const article of knowledgeBaseArticles) {
 <article id="kb-prerender" itemscope itemtype="https://schema.org/TechArticle">
   <nav class="kb-article__nav"><a href="/knowledge-base">← База знаний</a></nav>
   <header>
-    <p class="kb-prerender__eyebrow">Статья ${escape(article.number || article.slug)}</p>
+    <p class="kb-prerender__eyebrow">${escape(article.compare ? `Сравнение с ${article.compare}` : 'База знаний')}</p>
     <h1 itemprop="headline">${escape(article.title)}</h1>
     <p class="kb-prerender__lead" itemprop="description">${escape(article.compare || trim(article.summary, 220))}</p>
   </header>

--- a/src/pages/KnowledgeBase.tsx
+++ b/src/pages/KnowledgeBase.tsx
@@ -216,12 +216,9 @@ export default function KnowledgeBase() {
                     to={`/knowledge-base/${article.slug}.html`}
                     className="group block h-full p-6 rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 hover:border-blue-500/40 hover:shadow-md dark:hover:shadow-none transition-all"
                   >
-                    <div className="flex items-center justify-between mb-4">
-                      <span className="text-xs font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">
-                        №&nbsp;{article.number}
-                      </span>
+                    <div className="flex items-center mb-4">
                       <span className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 dark:text-slate-400">
-                        <GitCompare size={12} /> {article.compare}
+                        <GitCompare size={12} /> Сравнение с {article.compare}
                       </span>
                     </div>
                     <h2 className="text-lg font-bold mb-3 leading-snug text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">

--- a/src/pages/KnowledgeBaseArticle.tsx
+++ b/src/pages/KnowledgeBaseArticle.tsx
@@ -203,7 +203,7 @@ export default function KnowledgeBaseArticle() {
           >
             <div className="flex items-center gap-3 mb-5 flex-wrap">
               <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/10 text-blue-600 dark:text-blue-400 text-xs font-bold uppercase tracking-widest">
-                <BookOpen size={14} /> Статья № {article.number}
+                <BookOpen size={14} /> База знаний
               </span>
               <span className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 dark:text-slate-400">
                 <GitCompare size={12} /> Сравнение: {article.compare}
@@ -440,7 +440,7 @@ export default function KnowledgeBaseArticle() {
                       className="group block h-full p-4 rounded-xl border border-slate-200 dark:border-slate-800 hover:border-blue-500/40 transition-all"
                     >
                       <div className="text-xs text-slate-400 dark:text-slate-500 mb-1">
-                        №&nbsp;{r.number} · {r.compare}
+                        Сравнение с {r.compare}
                       </div>
                       <div className="text-sm font-semibold text-slate-700 dark:text-slate-200 group-hover:text-blue-500 transition-colors">
                         {r.shortTitle}


### PR DESCRIPTION
Номера статей вида «08a», «14b» переносились на второй строке на узких экранах и не несли смысловой нагрузки (порядок и так есть в slug). Убрал из всех мест, где они отображались:

- **Каталог** (`KnowledgeBase.tsx`): из карточки убран чип «№ N», осталось «Сравнение с Excel».
- **Страница статьи** (`KnowledgeBaseArticle.tsx`): чип «Статья № 08a» → «База знаний». В блоке «Похожие статьи» «№ 08a · Excel» → «Сравнение с Excel».
- **Prerender** (`prerender-knowledge-base.mjs`): эребрау статьи теперь «Сравнение с <инструмент>» или «База знаний», без номера.
- **OG-картинки** (`generate-og-images.mjs`): fallback для статей без `compare` теперь «База знаний» (а не «Статья 08a»). Карточки со сравнением — без изменений.

Поле `number` в `src/data/knowledgeBase.ts` оставил — мало ли где-то понадобится.

🤖 Generated with [Claude Code](https://claude.com/claude-code)