### PR TITLE
fix(blog): point main site to new blog and schedule GEO article

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-16T20:43:34.790Z for PR creation at branch issue-241-575eeb0585da for issue https://github.com/ideav/backlogram/issues/241

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-16T20:43:34.790Z for PR creation at branch issue-241-575eeb0585da for issue https://github.com/ideav/backlogram/issues/241

--- a/blog-v2/src/content/posts/prikladnoe-geo-optimizaciya-dlya-generativnyh-sistem.md
+++ b/blog-v2/src/content/posts/prikladnoe-geo-optimizaciya-dlya-generativnyh-sistem.md
@@ -1,10 +1,9 @@
 ---
 title: 'Прикладное GEO: как попасть в ответ ИИ-ассистента'
 description: Generative Engine Optimization — это новое SEO. Пока Яндекс не поставил оплату за клики в AI-ответы, честный контент побеждает рекламный бюджет. Как это использовать уже сейчас.
-pubDate: '2026-05-18'
+pubDate: '2026-05-17'
 category: Технологии
 author: Команда Интеграм
-canonical: https://blog.ideav.online/2026/05/prikladnoe-geo-optimizaciya-dlya-generativnyh-sistem
 tags:
 - маркетинг
 - технологии

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -41,7 +41,7 @@ export function Footer() {
               <li><Link to="/tokens.html" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Токены</Link></li>
               <li><a href="https://integram.io/terms.html" target="_blank" rel="noopener noreferrer" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Правила использования</a></li>
               <li><a href="https://rutube.ru/channel/41204904/videos/" target="_blank" rel="noopener noreferrer" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">RUTUBE</a></li>
-              <li><a href="https://blog.ideav.online/" target="_blank" rel="noopener noreferrer" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors flex items-center gap-2">Блог <ExternalLink size={12} /></a></li>
+              <li><a href="https://blog.ideav.ru/" target="_blank" rel="noopener noreferrer" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors flex items-center gap-2">Блог <ExternalLink size={12} /></a></li>
             </ul>
           </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,7 @@ export function Header() {
     { name: 'Примеры', href: '/#cases' },
     { name: 'Цены', href: '/#pricing' },
     { name: 'База знаний', href: '/knowledge-base.html' },
-    { name: 'Блог', href: 'https://blog.ideav.online/', external: true },
+    { name: 'Блог', href: 'https://blog.ideav.ru/', external: true },
   ]
 
   return (

--- a/tests/blog-geo-article-53.test.mjs
+++ b/tests/blog-geo-article-53.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const postsDir = new URL('../blog-v2/src/content/posts/', import.meta.url)
+const postFile = 'prikladnoe-geo-optimizaciya-dlya-generativnyh-sistem.md'
+const postPath = new URL(postFile, postsDir)
+
+function frontmatterValue(source, field) {
+  const match = source.match(new RegExp(`^${field}:\\s*['"]?(.*?)['"]?$`, 'm'))
+  return match?.[1]
+}
+
+test('GEO article is scheduled for May 17 as issue 53', () => {
+  assert.ok(existsSync(postPath), `expected ${postFile} to exist`)
+
+  const post = readFileSync(postPath, 'utf8')
+
+  assert.match(post, /title:\s*'Прикладное GEO: как попасть в ответ ИИ-ассистента'/)
+  assert.match(post, /pubDate:\s*['"]?2026-05-17['"]?/)
+  assert.doesNotMatch(post, /^canonical:/m, 'new article should use the new blog canonical URL')
+  assert.match(post, /Generative Engine Optimization/)
+})
+
+test('GEO article remains blog issue number 53 after rescheduling', () => {
+  const posts = readdirSync(postsDir)
+    .filter((file) => file.endsWith('.md'))
+    .map((file) => {
+      const source = readFileSync(new URL(file, postsDir), 'utf8')
+      return {
+        file,
+        pubDate: frontmatterValue(source, 'pubDate'),
+        draft: frontmatterValue(source, 'draft') === 'true',
+      }
+    })
+    .filter((post) => !post.draft)
+    .sort((a, b) => a.pubDate.localeCompare(b.pubDate) || a.file.localeCompare(b.file))
+
+  assert.equal(posts.findIndex((post) => post.file === postFile) + 1, 53)
+})

--- a/tests/site-blog-link.test.mjs
+++ b/tests/site-blog-link.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const headerSource = readFileSync(new URL('../src/components/Header.tsx', import.meta.url), 'utf8')
+const footerSource = readFileSync(new URL('../src/components/Footer.tsx', import.meta.url), 'utf8')
+
+test('main site blog links point to the new blog', () => {
+  for (const source of [headerSource, footerSource]) {
+    assert.doesNotMatch(source, /https:\/\/blog\.ideav\.online\//)
+    assert.match(source, /https:\/\/blog\.ideav\.ru\//)
+  }
+
+  assert.match(
+    headerSource,
+    /\{ name: 'Блог', href: 'https:\/\/blog\.ideav\.ru\/', external: true \}/,
+  )
+  assert.match(footerSource, /href="https:\/\/blog\.ideav\.ru\/"[\s\S]*>Блог/)
+})


### PR DESCRIPTION
Fixes #241

## Summary

- Replaced the main site “Блог” links in the header and footer from `https://blog.ideav.online/` to `https://blog.ideav.ru/`.
- Moved blog issue №53 (`prikladnoe-geo-optimizaciya-dlya-generativnyh-sistem`) to `pubDate: 2026-05-17`.
- Removed the old-blog canonical from the new GEO article so Astro uses the new `blog.ideav.ru` canonical URL.
- Added regression tests for the main Blog links and article №53 scheduling/canonical behavior.

## Verification

- `node --test tests/site-blog-link.test.mjs tests/blog-geo-article-53.test.mjs`
- `npm test` — 142 passing
- `cd blog-v2 && npm run build` — 79 pages built, Pagefind indexed 53 pages
- `npm run build` — root build and knowledge-base prerender completed
- `git diff --check`
