### PR TITLE
fix(blog-v2): replace .product-mark letter with Integram logo

### DIFF
--- a/blog-v2/src/components/Footer.astro
+++ b/blog-v2/src/components/Footer.astro
@@ -6,7 +6,11 @@ const year = new Date().getFullYear()
   <div class="product-container product-footer-grid">
     <section>
       <div class="product-brand">
-        <span class="product-mark">I</span>
+        <svg class="product-mark" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path fill="#307FE2" d="M0 0h100v100H0z"/>
+          <path d="M57.013 38.518l-4.038 4.24 6.903 7.24L37.392 73.34 8.858 64.344V35.656l28.534-8.996 5.165 5.486 4.084-4.19L39.101 20 3 31.38v37.24L39.101 80 68 49.998l-10.987-11.48z" fill="#fff"/>
+          <path d="M42.982 61.482l4.043-4.24-6.903-7.24L62.603 26.66l28.539 8.996v28.688L62.603 73.34l-5.174-5.5-4.084 4.195L60.899 80 97 68.624V31.38L60.899 20 32 50.002l10.982 11.48z" fill="#fff"/>
+        </svg>
         <span>Блог Интеграм</span>
       </div>
       <p class="mt-5 max-w-[32rem] leading-relaxed">

--- a/blog-v2/src/components/Header.astro
+++ b/blog-v2/src/components/Header.astro
@@ -11,7 +11,11 @@ function activeFor(paths: string[]): string {
 <header class="product-site-header">
   <div class="product-container product-nav-shell">
     <a href="/" class="product-brand" aria-label="Блог Интеграм — главная">
-      <span class="product-mark">I</span>
+      <svg class="product-mark" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path fill="#307FE2" d="M0 0h100v100H0z"/>
+        <path d="M57.013 38.518l-4.038 4.24 6.903 7.24L37.392 73.34 8.858 64.344V35.656l28.534-8.996 5.165 5.486 4.084-4.19L39.101 20 3 31.38v37.24L39.101 80 68 49.998l-10.987-11.48z" fill="#fff"/>
+        <path d="M42.982 61.482l4.043-4.24-6.903-7.24L62.603 26.66l28.539 8.996v28.688L62.603 73.34l-5.174-5.5-4.084 4.195L60.899 80 97 68.624V31.38L60.899 20 32 50.002l10.982 11.48z" fill="#fff"/>
+      </svg>
       <span>Блог Интеграм</span>
     </a>
 

--- a/blog-v2/src/styles/global.css
+++ b/blog-v2/src/styles/global.css
@@ -194,16 +194,12 @@ img {
 }
 
 .product-mark {
-  display: grid;
+  display: block;
   width: 2.5rem;
   height: 2.5rem;
-  place-items: center;
   border-radius: 8px;
-  background: var(--color-product-blue);
-  color: #ffffff;
-  font-size: 1.1rem;
-  font-weight: 850;
-  line-height: 1;
+  overflow: hidden;
+  flex-shrink: 0;
 }
 
 .product-nav-links {


### PR DESCRIPTION
## Summary

- `Header.astro`, `Footer.astro` — заменён `<span class="product-mark">I</span>` на inline SVG с логотипом Интеграм (два квинтета/пятиугольника, синий фон)
- `global.css` — обновлён стиль `.product-mark`: убраны текстовые и фоновые стили, добавлен `overflow: hidden` чтобы `border-radius` обрезал фон SVG

Closes #270