### PR TITLE
Открывать закладку регистрации при переходе по start.html#reg

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-23T06:49:05.675Z for PR creation at branch issue-274-e045fd6f8bc6 for issue https://github.com/ideav/backlogram/issues/274
+# Updated: 2026-05-30T07:29:22.932Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-23T06:49:05.675Z for PR creation at branch issue-274-e045fd6f8bc6 for issue https://github.com/ideav/backlogram/issues/274
-# Updated: 2026-05-30T07:29:22.932Z

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -230,7 +230,7 @@ export default function Home() {
                   <ArrowRight size={18} className="group-hover:translate-x-1 transition-transform" />
                 </a>
                 <a
-                  href="https://ideav.ru/start.html"
+                  href="https://ideav.ru/start.html#reg"
                   target="start"
                   rel="noopener noreferrer"
                   className="w-full sm:w-auto px-8 py-4 bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 hover:border-slate-300 dark:hover:border-slate-700 text-slate-700 dark:text-slate-300 font-semibold rounded-xl transition-all"
@@ -1163,7 +1163,7 @@ export default function Home() {
                 ))}
               </ul>
               <a
-                href="https://ideav.ru/start.html"
+                href="https://ideav.ru/start.html#reg"
                 target="start"
                 rel="noopener noreferrer"
                 className="w-full py-4 bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 text-slate-800 dark:text-white font-bold rounded-xl transition-all text-center block"

--- a/src/pages/KnowledgeBase.tsx
+++ b/src/pages/KnowledgeBase.tsx
@@ -254,7 +254,7 @@ export default function KnowledgeBase() {
             форму и отчёт — без программирования.
           </p>
           <a
-            href="https://ideav.ru/start.html"
+            href="https://ideav.ru/start.html#reg"
             target="start"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 px-8 py-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-all"

--- a/start.html
+++ b/start.html
@@ -20,5 +20,28 @@
     </script>
     <noscript><div><img src="https://mc.yandex.ru/watch/108758829" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
     <!-- /Yandex.Metrika counter -->
+    <script>
+      if (location.hash === '#reg') {
+        var _regTabAttempts = 0;
+        function _openRegTab() {
+          var tabs = document.querySelectorAll('[role="tab"]');
+          for (var i = 0; i < tabs.length; i++) {
+            if (tabs[i].textContent.trim() === 'Регистрация') {
+              tabs[i].click();
+              return;
+            }
+          }
+          if (_regTabAttempts < 20) {
+            _regTabAttempts++;
+            setTimeout(_openRegTab, 100);
+          }
+        }
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', _openRegTab);
+        } else {
+          _openRegTab();
+        }
+      }
+    </script>
   </body>
 </html>

--- a/tests/issue-281-start-reg-tab.test.mjs
+++ b/tests/issue-281-start-reg-tab.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const startHtml = readFileSync(new URL('../start.html', import.meta.url), 'utf8')
+const homeSource = readFileSync(new URL('../src/pages/Home.tsx', import.meta.url), 'utf8')
+const knowledgeBaseSource = readFileSync(new URL('../src/pages/KnowledgeBase.tsx', import.meta.url), 'utf8')
+
+test('start.html activates the registration tab when #reg hash is present', () => {
+  assert.match(
+    startHtml,
+    /location\.hash\s*===\s*['"]#reg['"]/,
+    'start.html must check location.hash for #reg',
+  )
+  assert.match(
+    startHtml,
+    /Регистрация/,
+    'start.html must look for the Регистрация tab by text',
+  )
+  assert.match(
+    startHtml,
+    /\.click\(\)/,
+    'start.html must click the registration tab to activate it',
+  )
+  assert.match(
+    startHtml,
+    /setTimeout.*_openRegTab/s,
+    'start.html must retry tab activation to handle deferred rendering',
+  )
+})
+
+test('registration-intent CTAs in Home use start.html#reg', () => {
+  const regIntentLabels = ['Попробовать самому', 'Начать бесплатно']
+
+  for (const label of regIntentLabels) {
+    const labelPos = homeSource.indexOf(label)
+    assert.ok(labelPos !== -1, `Expected to find the "${label}" CTA`)
+
+    // Search in the 600 chars surrounding the label (href comes before the text content)
+    const surrounding = homeSource.slice(Math.max(0, labelPos - 600), labelPos + label.length)
+    assert.match(
+      surrounding,
+      /href="https:\/\/ideav\.ru\/start\.html#reg"/,
+      `The "${label}" CTA must link to start.html#reg`,
+    )
+  }
+})
+
+test('KnowledgeBase registration CTA uses start.html#reg', () => {
+  const regSection = knowledgeBaseSource.match(
+    /Зарегистрируйте бесплатный аккаунт[\s\S]*?href="([^"]+)"/,
+  )
+  assert.ok(regSection, 'Expected the registration CTA section in KnowledgeBase')
+  assert.equal(
+    regSection[1],
+    'https://ideav.ru/start.html#reg',
+    'KnowledgeBase registration CTA must link to start.html#reg',
+  )
+})


### PR DESCRIPTION
## Решение

Fixes #281

### Проблема

При переходе по ссылке `start.html#reg` открывалась страница входа, но вкладка «Регистрация» не становилась активной автоматически.

### Изменения

**`start.html`** — добавлен JavaScript, который при наличии хэша `#reg` в URL ищет вкладку «Регистрация» по атрибуту `[role="tab"]` и тексту, затем кликает по ней. Используется механизм повторных попыток (до 20 раз с интервалом 100 мс), чтобы дождаться отрисовки модального окна.

**`src/pages/Home.tsx`** — регистрационные CTA («Попробовать самому», «Начать бесплатно») теперь ссылаются на `start.html#reg`.

**`src/pages/KnowledgeBase.tsx`** — CTA «Зарегистрируйте бесплатный аккаунт» теперь ссылается на `start.html#reg`.

### Тест

`tests/issue-281-start-reg-tab.test.mjs` — проверяет:
1. Наличие JS-обработчика `#reg` в `start.html`
2. Корректность ссылок в `Home.tsx` для регистрационных CTA
3. Корректность ссылки в `KnowledgeBase.tsx`

Все 164 теста проходят.