### PR TITLE
feat(seo): пререндер главной страницы для поисковиков

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "test": "node --test tests/*.test.mjs",
-    "build": "node scripts/generate-og-images.mjs && vite build && node scripts/prerender-knowledge-base.mjs",
+    "build": "node scripts/generate-og-images.mjs && vite build && node scripts/prerender-knowledge-base.mjs && node scripts/prerender-landing.mjs",
     "og-images": "node scripts/generate-og-images.mjs",
     "preview": "vite preview"
   },

--- a/scripts/prerender-landing.mjs
+++ b/scripts/prerender-landing.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Post-build prerender for the landing page (the SPA index route `/`).
+ *
+ * The site is a client-side React SPA: the built dist/index.html ships an
+ * empty <div id="root"></div>, so search engines (especially Yandex, whose
+ * JS rendering is limited) and no-JS clients see a page with no content.
+ * The knowledge base already solves this via scripts/prerender-knowledge-base.mjs;
+ * this script does the same for the home page.
+ *
+ * It rewrites dist/index.html, injecting a fully-rendered static snapshot of
+ * the landing into #root. When React boots, createRoot().render(<App/>)
+ * replaces #root with the live SPA, so the static fallback disappears for
+ * real visitors but stays in the HTTP response for crawlers.
+ *
+ * Must run AFTER prerender-knowledge-base.mjs, because that script uses the
+ * clean dist/index.html as its template — we overwrite the home page last.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = resolve(__dirname, '..')
+const dist = resolve(root, 'dist')
+const SITE = 'https://ideav.ru'
+const PUBLISHER = 'Интеграм'
+
+function escape(s) {
+  return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Static snapshot of the landing — mirrors src/pages/Home.tsx section
+//  headings so crawlers see representative content. The brand + category
+//  ("конструктор Интеграм / конструктор приложений и баз данных") appears in
+//  the H1 and lead so the page is relevant to the brand query.
+// ───────────────────────────────────────────────────────────────────────────
+const sections = [
+  {
+    h: 'Своя разработка — это хорошо, но…',
+    p: 'Интеграм встраивается в вашу ИТ-среду и закрывает очередь задач (бэклог) быстрее обычной разработки, не отнимая контроль над данными и кодом.',
+  },
+  {
+    h: 'Для кого',
+    p: 'Компании, которым нужны внутренние приложения, учёт и автоматизация процессов без долгого цикла заказной разработки.',
+  },
+  {
+    h: 'Работаем там, где обычные конструкторы «падают»',
+    p: 'Реляционные данные, сотни тысяч записей, права доступа на уровне строк, локальное размещение — сценарии, где Excel, Google Sheets, Airtable и Notion упираются в лимиты.',
+  },
+  {
+    h: 'Изменения вносятся бизнес-аналитиками, а не программистами',
+    p: 'Поля, формы, отчёты и дашборды настраиваются без релизов и без переписывания кода.',
+  },
+  {
+    h: 'Готовые типы проектов для вашего бэклога',
+    p: 'CRM, учётные системы, порталы, формы сбора данных, отчётность и интеграции по API (JSON).',
+  },
+  {
+    h: 'Как начать быстро и комфортно',
+    p: 'Пилотный проект, локальная лицензия или разработка под ключ — с системным аналитиком и разработчиком платформы на вашей стороне.',
+  },
+  {
+    h: 'Тарифы на хостинг в облаке',
+    p: 'Планы «Знакомство», «Стартап» и «Масштабируемый» — от пробного использования до промышленной нагрузки.',
+  },
+]
+
+const sectionsHtml = sections
+  .map(
+    (s) => `
+      <section class="lp-prerender__group">
+        <h2>${escape(s.h)}</h2>
+        <p>${escape(s.p)}</p>
+      </section>`
+  )
+  .join('')
+
+const bodyHtml = `
+<article id="lp-prerender" itemscope itemtype="https://schema.org/SoftwareApplication">
+  <header>
+    <p class="lp-prerender__eyebrow">Автоматизация без программистов</p>
+    <h1 itemprop="name">Интеграм — конструктор приложений и баз данных</h1>
+    <p class="lp-prerender__lead" itemprop="description">
+      Интеграм — российский no-code конструктор для создания внутренних приложений,
+      баз данных, форм и отчётов без программирования. Инструмент для ускорения
+      внутренней разработки: разгрузите программистов, не жертвуя контролем над данными.
+      Аналог Airtable, замена Excel и Google Sheets для реляционных данных и автоматизации бизнеса.
+    </p>
+  </header>
+  ${sectionsHtml}
+  <footer class="lp-prerender__footer">
+    <p>
+      <a href="#cta">Отправить задачу из очереди задач (бэклога)</a> ·
+      <a href="/knowledge-base">База знаний</a>
+    </p>
+  </footer>
+</article>
+<style>
+  #lp-prerender { max-width: 64rem; margin: 0 auto; padding: 4rem 1rem 2rem;
+    font-family: ui-sans-serif, system-ui, sans-serif; color: #1e293b; }
+  #lp-prerender h1 { font-size: 2.4rem; line-height: 1.1; margin: 0.5rem 0 1rem; }
+  #lp-prerender h2 { font-size: 1.35rem; margin: 2.25rem 0 0.5rem; }
+  #lp-prerender p  { line-height: 1.6; margin: 0.5rem 0; }
+  #lp-prerender .lp-prerender__eyebrow { text-transform: uppercase; letter-spacing: 0.1em;
+    font-size: 0.72rem; color: #3b82f6; font-weight: 700; margin: 0; }
+  #lp-prerender .lp-prerender__lead { font-size: 1.1rem; color: #475569; max-width: 50rem; }
+  #lp-prerender .lp-prerender__footer { margin-top: 3rem; padding-top: 1.5rem;
+    border-top: 1px solid #e2e8f0; font-size: 0.92rem; color: #475569; }
+  @media (prefers-color-scheme: dark) {
+    #lp-prerender { color: #e2e8f0; }
+    #lp-prerender .lp-prerender__lead, #lp-prerender .lp-prerender__footer { color: #94a3b8; }
+  }
+</style>`
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Structured data: WebSite + Organization + SoftwareApplication
+// ───────────────────────────────────────────────────────────────────────────
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': `${SITE}/#website`,
+      url: `${SITE}/`,
+      name: PUBLISHER,
+      inLanguage: 'ru',
+      publisher: { '@id': `${SITE}/#organization` },
+    },
+    {
+      '@type': 'Organization',
+      '@id': `${SITE}/#organization`,
+      name: PUBLISHER,
+      url: `${SITE}/`,
+      logo: { '@type': 'ImageObject', url: `${SITE}/logos/integram-og.png` },
+    },
+    {
+      '@type': 'SoftwareApplication',
+      '@id': `${SITE}/#app`,
+      name: 'Интеграм — конструктор приложений и баз данных',
+      applicationCategory: 'BusinessApplication',
+      operatingSystem: 'Web',
+      url: `${SITE}/`,
+      inLanguage: 'ru',
+      description:
+        'Российский no-code конструктор для создания внутренних приложений, баз данных, форм и отчётов без программирования. Аналог Airtable, замена Excel и Google Sheets.',
+      publisher: { '@id': `${SITE}/#organization` },
+    },
+  ],
+}
+
+const canonical = `${SITE}/`
+const ogTitle = 'Интеграм — конструктор приложений и баз данных, автоматизация бизнеса'
+const ogDescription =
+  'Российский no-code конструктор приложений и баз данных. Создавайте внутренние приложения, формы, отчёты и автоматизацию без программирования. Аналог Airtable, замена Excel.'
+const ogImage = `${SITE}/og/knowledge-base.png`
+
+const headTags = [
+  `<link rel="canonical" href="${escape(canonical)}" />`,
+  `<meta property="og:type" content="website" />`,
+  `<meta property="og:url" content="${escape(canonical)}" />`,
+  `<meta property="og:title" content="${escape(ogTitle)}" />`,
+  `<meta property="og:description" content="${escape(ogDescription)}" />`,
+  `<meta property="og:image" content="${escape(ogImage)}" />`,
+  `<meta property="og:image:width" content="1200" />`,
+  `<meta property="og:image:height" content="630" />`,
+  `<meta property="og:locale" content="ru_RU" />`,
+  `<meta property="og:site_name" content="${PUBLISHER}" />`,
+  `<meta name="twitter:card" content="summary_large_image" />`,
+  `<meta name="twitter:title" content="${escape(ogTitle)}" />`,
+  `<meta name="twitter:description" content="${escape(ogDescription)}" />`,
+  `<meta name="twitter:image" content="${escape(ogImage)}" />`,
+  `<script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>`,
+].join('\n    ')
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Patch dist/index.html in place
+// ───────────────────────────────────────────────────────────────────────────
+const indexPath = resolve(dist, 'index.html')
+const source = readFileSync(indexPath, 'utf8')
+
+if (source.includes('id="lp-prerender"')) {
+  console.log('• landing already prerendered, skipping')
+  process.exit(0)
+}
+if (!source.includes('<div id="root"></div>')) {
+  console.error('✗ prerender-landing: <div id="root"></div> not found in dist/index.html')
+  process.exit(1)
+}
+
+const html = source
+  .replace('</head>', `    ${headTags}\n  </head>`)
+  .replace('<div id="root"></div>', `<div id="root">${bodyHtml}</div>`)
+
+writeFileSync(indexPath, html)
+console.log(`✓ landing prerendered → dist/index.html (${html.length} bytes)`)

--- a/tests/prerender-landing.test.mjs
+++ b/tests/prerender-landing.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, cpSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+const repo = new URL('..', import.meta.url).pathname
+const scriptSrc = readFileSync(resolve(repo, 'scripts/prerender-landing.mjs'), 'utf8')
+const indexHtml = readFileSync(resolve(repo, 'index.html'), 'utf8')
+
+test('build pipeline runs prerender-landing after the knowledge base prerender', () => {
+  const pkg = JSON.parse(readFileSync(resolve(repo, 'package.json'), 'utf8'))
+  const build = pkg.scripts.build
+  assert.match(build, /prerender-landing\.mjs/)
+  assert.ok(
+    build.indexOf('prerender-knowledge-base.mjs') < build.indexOf('prerender-landing.mjs'),
+    'landing prerender must run after the knowledge base prerender',
+  )
+})
+
+test('prerender-landing fills #root and injects SEO head tags into dist/index.html', () => {
+  // Arrange: a fake build output that mirrors the real SPA shell.
+  const work = mkdtempSync(resolve(tmpdir(), 'lp-prerender-'))
+  mkdirSync(resolve(work, 'dist'), { recursive: true })
+  mkdirSync(resolve(work, 'scripts'), { recursive: true })
+  cpSync(resolve(repo, 'scripts/prerender-landing.mjs'), resolve(work, 'scripts/prerender-landing.mjs'))
+  writeFileSync(resolve(work, 'dist/index.html'), indexHtml)
+
+  // Act
+  execFileSync('node', ['scripts/prerender-landing.mjs'], { cwd: work })
+  const out = readFileSync(resolve(work, 'dist/index.html'), 'utf8')
+
+  // Assert: #root is no longer empty and carries a crawlable H1 with the brand.
+  assert.doesNotMatch(out, /<div id="root"><\/div>/, '#root must not be left empty')
+  assert.match(out, /<div id="root">\s*<article id="lp-prerender"/)
+  assert.match(out, /<h1[^>]*>Интеграм — конструктор приложений и баз данных<\/h1>/)
+
+  // Representative section headings from Home.tsx are present.
+  assert.match(out, /Работаем там, где обычные конструкторы/)
+  assert.match(out, /Готовые типы проектов для вашего бэклога/)
+
+  // SEO head tags: canonical, Open Graph, and SoftwareApplication JSON-LD.
+  assert.match(out, /<link rel="canonical" href="https:\/\/ideav\.ru\/" \/>/)
+  assert.match(out, /<meta property="og:title"/)
+  assert.match(out, /application\/ld\+json/)
+  assert.match(out, /"@type":"SoftwareApplication"/)
+})
+
+test('prerender-landing is idempotent (safe to run twice)', () => {
+  const work = mkdtempSync(resolve(tmpdir(), 'lp-prerender-idem-'))
+  mkdirSync(resolve(work, 'dist'), { recursive: true })
+  mkdirSync(resolve(work, 'scripts'), { recursive: true })
+  cpSync(resolve(repo, 'scripts/prerender-landing.mjs'), resolve(work, 'scripts/prerender-landing.mjs'))
+  writeFileSync(resolve(work, 'dist/index.html'), indexHtml)
+
+  execFileSync('node', ['scripts/prerender-landing.mjs'], { cwd: work })
+  const once = readFileSync(resolve(work, 'dist/index.html'), 'utf8')
+  execFileSync('node', ['scripts/prerender-landing.mjs'], { cwd: work })
+  const twice = readFileSync(resolve(work, 'dist/index.html'), 'utf8')
+
+  assert.equal(once, twice, 'running the prerender twice must not double-inject content')
+})
+
+test('script documents that it must run after the knowledge base prerender', () => {
+  assert.match(scriptSrc, /AFTER prerender-knowledge-base/)
+})


### PR DESCRIPTION
## Проблема

Сайт — клиентский React SPA. В собранном `dist/index.html` уходит пустой `<div id="root"></div>`, поэтому поисковики (особенно Яндекс с его слабым рендерингом JS) и no-JS клиенты видят главную **без контента** — ранжировать по брендовым запросам вроде «конструктор интеграм» нечем. База знаний эту проблему уже решает через `prerender-knowledge-base.mjs`, а главная — нет.

## Решение

Новый post-build шаг по тому же образцу, что и KB-пререндер:

- **`scripts/prerender-landing.mjs`** — переписывает `dist/index.html`, вставляя в `#root` статический снимок лендинга: `<h1>Интеграм — конструктор приложений и баз данных</h1>`, заголовки секций из `Home.tsx`, `canonical` + Open Graph + JSON-LD (`WebSite` + `Organization` + `SoftwareApplication`). Чистый Node, без зависимостей.
- **`package.json`** — шаг добавлен в `build` **последним** (после KB-пререндера, чтобы тот брал чистый шаблон).
- **`tests/prerender-landing.test.mjs`** — 4 теста: порядок в пайплайне, реальный прогон на фикстуре, идемпотентность.

Когда загружается React, `createRoot().render()` затирает `#root` живым SPA — пользователь видит обычный сайт, краулер получает реальный контент.

## Верификация

- ✅ `npm run build` отрабатывает целиком → `dist/index.html` 7.7 КБ с заполненным `#root`, H1, canonical, OG, JSON-LD.
- ✅ `vite preview` + headless-браузер: React монтируется поверх снимка, статический блок `lp-prerender` корректно удаляется, дублирования нет.
- ✅ Новые тесты проходят (4/4). 5 падающих блоговых тестов в общем наборе — предсуществующие (зависят от даты/порядка), к этим изменениям отношения не имеют.

## Вне рамок этого PR

`<title>` и `<meta description>` главной не менялись — это отдельный, более сильный рычаг под запрос «конструктор интеграм» (следующий шаг).

🤖 Generated with [Claude Code](https://claude.com/claude-code)