### PR TITLE
feat(seo): title и meta description главной под запрос «конструктор интеграм»

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1" />
-    <meta name="description" content="Конструктор баз данных и приложений для создания форм и замены экселя" />
+    <meta name="description" content="Интеграм — российский конструктор приложений и баз данных без программирования. Формы, отчёты и автоматизация бизнеса. Аналог Airtable, замена Excel." />
     <meta name="keywords" content="интеграмщик,автоматизация бизнеса,гугл таблицы,создать базу данных,конструктор интеграм,интеграм,российский airtable,аналог airtable,airtable,google-tables,конструктор приложений,приложение без программирования,квинтетная модель данных,no-code,nocode,low code,зерокод,конструктор SQL,замена excel" />
-    <title>Интеграм — автоматизация бизнеса, конструктор приложений</title>
+    <title>Конструктор Интеграм — приложения и базы данных без кода</title>
   </head>
   <body>
     <!-- Yandex.Metrika counter -->

--- a/tests/index-seo-meta.test.mjs
+++ b/tests/index-seo-meta.test.mjs
@@ -4,10 +4,14 @@ import { test } from 'node:test'
 
 const indexSource = readFileSync(new URL('../index.html', import.meta.url), 'utf8')
 
-test('index.html exposes SEO description and keywords', () => {
+test('index.html exposes SEO title, description and keywords', () => {
   assert.match(
     indexSource,
-    /<meta name="description" content="Конструктор баз данных и приложений для создания форм и замены экселя" \/>/,
+    /<title>Конструктор Интеграм — приложения и базы данных без кода<\/title>/,
+  )
+  assert.match(
+    indexSource,
+    /<meta name="description" content="Интеграм — российский конструктор приложений и баз данных без программирования\. Формы, отчёты и автоматизация бизнеса\. Аналог Airtable, замена Excel\." \/>/,
   )
   assert.match(
     indexSource,


### PR DESCRIPTION
## Проблема

Главная таргетировала брендовый запрос «конструктор интеграм» только через `<meta keywords>`, который Яндекс и Google игнорируют. При этом:
- `<title>` = «Интеграм — автоматизация бизнеса, конструктор приложений» — слова «Интеграм» и «конструктор» разнесены, точного вхождения нет;
- `<meta description>` вообще не содержала слова «Интеграм».

## Изменения (`index.html`)

- **`<title>`** → `Конструктор Интеграм — приложения и базы данных без кода`
  Точная фраза «Конструктор Интеграм» в начале, ~55 символов (не обрежется в сниппете).
- **`<meta description>`** → `Интеграм — российский конструктор приложений и баз данных без программирования. Формы, отчёты и автоматизация бизнеса. Аналог Airtable, замена Excel.`
  Бренд + категория в начале, ключевые ценности (no-code, аналог Airtable, замена Excel).
- `keywords` не трогал.
- `tests/index-seo-meta.test.mjs` обновлён под новые title и description.

## Альтернативные варианты title (на выбор в ревью)

- B: `Интеграм — конструктор приложений и баз данных, замена Excel`
- C: `Конструктор приложений Интеграм — автоматизация бизнеса`

## Верификация

- ✅ `node --test tests/index-seo-meta.test.mjs` — зелёный.
- ✅ Полный набор: 168 pass / 5 fail — те же предсуществующие блоговые падения (дата/порядок), к этим правкам не относятся.

## Связь с #295

Независимый PR (ветка от `main`). #295 добавляет видимый контент в `#root` для краулеров; этот — оптимизирует title/description. Лучше всего работают вместе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)