### PR TITLE
fix(excel-to-app): перенести абзац оффера под форму и сделать приглушённым (#339)

### DIFF
--- a/scripts/prerender-excel-to-app.mjs
+++ b/scripts/prerender-excel-to-app.mjs
@@ -110,15 +110,15 @@ const bodyHtml = `
       Никаких формул, макросов и настройки: загружаете файлы, указываете тематику и
       контакт — и получаете ссылку на готовую базу со своими данными.
     </p>
-    <p class="etl-prerender__lead">
-      Приложение будет в виде схемы данных, основных рабочих мест и базовых действий,
-      которые описаны в вашем ТЗ или могут быть из него однозначно поняты. Вы сможете
-      сразу его протестировать и потом забрать себе навсегда за 12 500 ₽.
-    </p>
   </header>
   ${stepsHtml}
   <h2>Частые вопросы</h2>
   ${faqHtml}
+  <p class="etl-prerender__note">
+    Приложение будет в виде схемы данных, основных рабочих мест и базовых действий,
+    которые описаны в вашем ТЗ или могут быть из него однозначно поняты. Вы сможете
+    сразу его протестировать и потом забрать себе навсегда за 12 500 ₽.
+  </p>
   <footer class="etl-prerender__footer">
     <p>
       <a href="${PATH}#excel-form">Загрузить файлы</a> ·
@@ -137,6 +137,8 @@ const bodyHtml = `
   #etl-prerender .etl-prerender__eyebrow { text-transform: uppercase; letter-spacing: 0.1em;
     font-size: 0.72rem; color: #3b82f6; font-weight: 700; margin: 0; }
   #etl-prerender .etl-prerender__lead { font-size: 1.1rem; color: #475569; max-width: 50rem; }
+  #etl-prerender .etl-prerender__note { margin-top: 2.5rem; font-size: 1rem;
+    color: #475569; max-width: 50rem; }
   #etl-prerender .etl-prerender__footer { margin-top: 3rem; padding-top: 1.5rem;
     border-top: 1px solid #e2e8f0; font-size: 0.92rem; color: #475569; }
   /* Dark colours follow the app theme (.dark on <html>, set synchronously by the
@@ -146,7 +148,7 @@ const bodyHtml = `
      site's dark theme while the OS is light sees dark text on a dark background —
      a black screen during loading (issue #325). */
   .dark #etl-prerender { color: #e2e8f0; }
-  .dark #etl-prerender .etl-prerender__lead, .dark #etl-prerender .etl-prerender__footer { color: #94a3b8; }
+  .dark #etl-prerender .etl-prerender__lead, .dark #etl-prerender .etl-prerender__note, .dark #etl-prerender .etl-prerender__footer { color: #94a3b8; }
 </style>`
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/pages/ExcelToApp.tsx
+++ b/src/pages/ExcelToApp.tsx
@@ -445,18 +445,6 @@ export default function ExcelToApp() {
             Никаких формул, макросов и настройки — только готовый результат со ссылкой.
           </motion.p>
 
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.25 }}
-            className="max-w-3xl mx-auto text-lg md:text-xl text-slate-600 dark:text-slate-300 leading-relaxed mb-10"
-          >
-            Приложение будет в виде схемы данных, основных рабочих мест и базовых
-            действий, которые описаны в вашем ТЗ или могут быть из него однозначно
-            поняты. Вы сможете сразу его протестировать и потом забрать себе навсегда
-            за <span className="font-bold text-slate-900 dark:text-white">12 500 ₽</span>.
-          </motion.p>
-
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -694,6 +682,15 @@ export default function ExcelToApp() {
           </p>
         </div>
       </section>
+
+      <div className="max-w-2xl mx-auto px-4 pb-16">
+        <p className="text-center text-base text-slate-600 dark:text-slate-300 leading-relaxed">
+          Приложение будет в виде схемы данных, основных рабочих мест и базовых
+          действий, которые описаны в вашем ТЗ или могут быть из него однозначно
+          поняты. Вы сможете сразу его протестировать и потом забрать себе навсегда
+          за 12 500 ₽.
+        </p>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Закрывает #339.

Правка к уже смерженному #338 (там добавлялся блок «приложение в виде схемы данных… забрать за 12 500 ₽»). Коммит с этой правкой случайно ушёл в ветку #338 уже после мержа и в `main` не попал — выношу отдельным PR.

## Что сделано (`src/pages/ExcelToApp.tsx`)
Блок оффера убран из hero (где бросался в глаза) и помещён **ниже секции `#excel-form`**: по центру, **обычным читаемым стилем** (`text-base`, основной цвет текста `text-slate-600 dark:text-slate-300`), цена `12 500 ₽` без выделения. Не выпячивается, но и не выглядит спрятанным/затемнённым.

## SEO/no-JS пререндер (`scripts/prerender-excel-to-app.mjs`)
Тот же абзац перенесён из шапки к футеру, класс `etl-prerender__note` (обычный размер 1rem и цвет, в тёмной теме — как у остального текста).

## Проверки
- `tsc --noEmit` — без ошибок.
- `vite build` — успешно.
- `node --test tests/prerender-excel-to-app.test.mjs` — 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)