### PR TITLE
feat(excel-to-app): сравнение с зарубежными агент-платформами + страница разбора (#360)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "test": "node --test tests/*.test.mjs",
-    "build": "node scripts/generate-og-images.mjs && vite build && node scripts/prerender-knowledge-base.mjs && node scripts/prerender-excel-to-app.mjs && node scripts/prerender-landing.mjs",
+    "build": "node scripts/generate-og-images.mjs && vite build && node scripts/prerender-knowledge-base.mjs && node scripts/prerender-excel-to-app.mjs && node scripts/prerender-agent-platforms.mjs && node scripts/prerender-landing.mjs",
     "og-images": "node scripts/generate-og-images.mjs",
     "preview": "vite preview"
   },

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -13,6 +13,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://ideav.ru/agent-platforms.html</loc>
+    <lastmod>2026-06-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://ideav.ru/knowledge-base.html</loc>
     <lastmod>2026-05-13</lastmod>
     <changefreq>weekly</changefreq>

--- a/scripts/prerender-agent-platforms.mjs
+++ b/scripts/prerender-agent-platforms.mjs
@@ -111,6 +111,23 @@ const pillarsHtml = pillars
   )
   .join('')
 
+const ruPlatforms = [
+  { h: 'Bpium', p: 'No-code конструктор с таблицами, формами, API и правами до уровня поля, но приложение собирает человек — ИИ-генерации нет.' },
+  { h: 'ELMA365', p: 'Low-code экосистема BPM/CRM/КЭДО с ИИ-ассистентом, который помогает человеку в визуальном конструкторе (human-in-the-loop).' },
+  { h: 'BPMSoft', p: 'Low-code BPM/CRM (замена Creatio, реестр РФ, ФСТЭК) с LLM-агентами, но агент автоматизирует бизнес-процессы, а не схему и права.' },
+  { h: 'AppMaster', p: 'No-code с ИИ-генерацией исходного кода (бэкенд, веб, мобайл), но это реальный код с риском поломки и без единого админ-API.' },
+]
+
+const ruPlatformsHtml = ruPlatforms
+  .map(
+    (p) => `
+      <section class="ap-prerender__group">
+        <h3>${escape(p.h)}</h3>
+        <p>${escape(p.p)}</p>
+      </section>`
+  )
+  .join('')
+
 const bodyHtml = `
 <article id="ap-prerender" itemscope itemtype="https://schema.org/Article">
   <header>
@@ -118,21 +135,25 @@ const bodyHtml = `
     <h1 itemprop="headline">Сервис целиком создаёт и администрирует агент — кто это уже умеет</h1>
     <p class="ap-prerender__lead" itemprop="description">
       Подход «приложение полностью собирается ИИ-агентом» — горячий фронт. Ниже честное сравнение
-      Интеграма с лучшими зарубежными решениями (Retool AI, Power Platform Copilot, NocoDB, Appsmith),
-      где агент может выступать разработчиком и администратором.
+      Интеграма с лучшими решениями за рубежом (Retool AI, Power Platform Copilot, NocoDB, Appsmith)
+      и в России (Bpium, ELMA365, BPMSoft, AppMaster), где агент может выступать разработчиком и
+      администратором.
     </p>
   </header>
   <h2>Главные зарубежные конкуренты</h2>
   ${competitorsHtml}
+  <h2>Российские аналоги</h2>
+  ${ruPlatformsHtml}
   <h2>Чем Интеграм уникален для полной автоматизации</h2>
   ${pillarsHtml}
   <section class="ap-prerender__group">
     <h2>Вывод</h2>
     <p>
-      За рубежом нет точного аналога Интеграма по уровню контроля агента над платформой. Ближайшие
-      конкуренты заточены на human-in-the-loop: человек кликает в интерфейсе, агент помогает.
-      Интеграм — платформа, где агент проходит полный цикл: структура базы → наполнение → роли и
-      права → меню → шаблоны → тестовые данные, и всё это единообразными API-вызовами.
+      Ни за рубежом, ни в России нет точного аналога Интеграма по уровню контроля агента над
+      платформой. Зарубежные и российские конкуренты заточены на human-in-the-loop: человек кликает
+      в интерфейсе, агент помогает. Интеграм — платформа, где агент проходит полный цикл: структура
+      базы → наполнение → роли и права → меню → шаблоны → тестовые данные, и всё это единообразными
+      API-вызовами.
     </p>
   </section>
   <footer class="ap-prerender__footer">
@@ -168,9 +189,9 @@ const bodyHtml = `
 // ───────────────────────────────────────────────────────────────────────────
 const canonical = `${SITE}${PATH}`
 const ogTitle =
-  'Агент создаёт приложение: Интеграм против Retool, Power Platform, NocoDB и Appsmith'
+  'Агент создаёт приложение: Интеграм против зарубежных и российских low-code платформ'
 const ogDescription =
-  'Подробное сравнение Интеграма с лучшими зарубежными low-code платформами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: Retool AI, Power Platform Copilot, NocoDB, Appsmith.'
+  'Подробное сравнение Интеграма с low-code платформами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: за рубежом — Retool AI, Power Platform Copilot, NocoDB, Appsmith; в России — Bpium, ELMA365, BPMSoft, AppMaster.'
 const ogImage = `${SITE}/og/knowledge-base.png`
 
 const jsonLd = {

--- a/scripts/prerender-agent-platforms.mjs
+++ b/scripts/prerender-agent-platforms.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Post-build prerender for the «Агент создаёт приложение: Интеграм против
+ * зарубежных платформ» analysis page (the SPA route `/agent-platforms.html`).
+ *
+ * Like scripts/prerender-excel-to-app.mjs, the site is a client-side React SPA:
+ * the built dist/index.html ships an empty <div id="root"></div>, so crawlers
+ * (especially Yandex, whose JS rendering is limited), social-preview bots and
+ * no-JS clients would see an empty page at /agent-platforms.html.
+ *
+ * This script takes the clean dist/index.html as a template and writes a
+ * sibling dist/agent-platforms.html with:
+ *   - a tightened <title>, meta description/keywords
+ *   - <link rel="canonical">
+ *   - Open Graph + Twitter Card tags
+ *   - JSON-LD (WebPage + Article)
+ *   - a static, crawlable snapshot of the comparison injected into #root
+ *
+ * When React boots, createRoot().render(<App/>) replaces #root with the live
+ * SPA, so the static fallback disappears for real visitors but stays in the
+ * HTTP response for crawlers.
+ *
+ * Must run AFTER prerender-knowledge-base.mjs and BEFORE prerender-landing.mjs:
+ * it reads the still-clean dist/index.html (prerender-landing overwrites the
+ * home page last, injecting its own #lp-prerender content into #root).
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = resolve(__dirname, '..')
+const dist = resolve(root, 'dist')
+const SITE = 'https://ideav.ru'
+const PUBLISHER = 'Интеграм'
+const PATH = '/agent-platforms.html'
+
+function escape(s) {
+  return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Static snapshot — mirrors src/pages/AgentPlatforms.tsx headings so crawlers
+//  see the representative comparison content.
+// ───────────────────────────────────────────────────────────────────────────
+const competitors = [
+  {
+    h: 'Retool + Retool AI',
+    p: 'По описанию генерирует приложение, но права и пользователей администрирует человек в интерфейсе, а агент заперт в песочнице.',
+  },
+  {
+    h: 'Microsoft Power Platform + Copilot',
+    p: 'Создаёт таблицы Dataverse и Canvas-приложения, но управление ролями безопасности недоступно агенту, а интерфейс собирается из готовых блоков.',
+  },
+  {
+    h: 'NocoDB',
+    p: 'Полный REST API для таблиц, связей и ролей, но изменения идут в реальный SQL — неосторожный агент может удалить колонку с данными.',
+  },
+  {
+    h: 'Appsmith',
+    p: 'GitOps через JSON и API, но управление пользователями и ролями остаётся в интерфейсе, а агенту нужно знать SQL-схему.',
+  },
+]
+
+const pillars = [
+  {
+    h: 'Единая модель данных (EAV)',
+    p: 'Все данные в одной физической таблице — ошибка агента создаёт новый тип, а не разрушает структуру.',
+  },
+  {
+    h: 'Единый API для всего',
+    p: 'Пользователи, роли, таблицы, колонки и связи — через одни и те же вызовы, без переключения между REST, SQL и SDK.',
+  },
+  {
+    h: 'Сквозные права и маски через API',
+    p: 'Ролевую модель полностью пишет скрипт, а не клики в интерфейсе.',
+  },
+  {
+    h: 'Чистые HTML/JS-шаблоны',
+    p: 'Агент генерирует интерфейс напрямую, без привязки к проприетарным виджетам.',
+  },
+  {
+    h: 'Идемпотентные вызовы',
+    p: 'Повторный запуск скрипта не падает и не плодит дубли.',
+  },
+]
+
+const competitorsHtml = competitors
+  .map(
+    (c) => `
+      <section class="ap-prerender__group">
+        <h2>${escape(c.h)}</h2>
+        <p>${escape(c.p)}</p>
+      </section>`
+  )
+  .join('')
+
+const pillarsHtml = pillars
+  .map(
+    (p) => `
+      <section class="ap-prerender__group">
+        <h3>${escape(p.h)}</h3>
+        <p>${escape(p.p)}</p>
+      </section>`
+  )
+  .join('')
+
+const bodyHtml = `
+<article id="ap-prerender" itemscope itemtype="https://schema.org/Article">
+  <header>
+    <p class="ap-prerender__eyebrow">Агент как полноценный разработчик</p>
+    <h1 itemprop="headline">Сервис целиком создаёт и администрирует агент — кто это уже умеет</h1>
+    <p class="ap-prerender__lead" itemprop="description">
+      Подход «приложение полностью собирается ИИ-агентом» — горячий фронт. Ниже честное сравнение
+      Интеграма с лучшими зарубежными решениями (Retool AI, Power Platform Copilot, NocoDB, Appsmith),
+      где агент может выступать разработчиком и администратором.
+    </p>
+  </header>
+  <h2>Главные зарубежные конкуренты</h2>
+  ${competitorsHtml}
+  <h2>Чем Интеграм уникален для полной автоматизации</h2>
+  ${pillarsHtml}
+  <section class="ap-prerender__group">
+    <h2>Вывод</h2>
+    <p>
+      За рубежом нет точного аналога Интеграма по уровню контроля агента над платформой. Ближайшие
+      конкуренты заточены на human-in-the-loop: человек кликает в интерфейсе, агент помогает.
+      Интеграм — платформа, где агент проходит полный цикл: структура базы → наполнение → роли и
+      права → меню → шаблоны → тестовые данные, и всё это единообразными API-вызовами.
+    </p>
+  </section>
+  <footer class="ap-prerender__footer">
+    <p>
+      <a href="/excel-to-app.html#excel-form">Загрузить Excel и получить приложение</a> ·
+      <a href="/">На главную</a> ·
+      <a href="/knowledge-base">База знаний</a>
+    </p>
+  </footer>
+</article>
+<style>
+  #ap-prerender { max-width: 64rem; margin: 0 auto; padding: 4rem 1rem 2rem;
+    font-family: ui-sans-serif, system-ui, sans-serif; color: #1e293b; }
+  #ap-prerender h1 { font-size: 2.4rem; line-height: 1.1; margin: 0.5rem 0 1rem; }
+  #ap-prerender h2 { font-size: 1.35rem; margin: 2.25rem 0 0.5rem; }
+  #ap-prerender h3 { font-size: 1.1rem; margin: 1.5rem 0 0.25rem; }
+  #ap-prerender p  { line-height: 1.6; margin: 0.5rem 0; }
+  #ap-prerender .ap-prerender__eyebrow { text-transform: uppercase; letter-spacing: 0.1em;
+    font-size: 0.72rem; color: #3b82f6; font-weight: 700; margin: 0; }
+  #ap-prerender .ap-prerender__lead { font-size: 1.1rem; color: #475569; max-width: 50rem; }
+  #ap-prerender .ap-prerender__footer { margin-top: 3rem; padding-top: 1.5rem;
+    border-top: 1px solid #e2e8f0; font-size: 0.92rem; color: #475569; }
+  /* Dark colours follow the app theme (.dark on <html>, set synchronously by the
+     inline <head> script from localStorage) — NOT prefers-color-scheme, so a
+     visitor who picked the dark theme while the OS is light does not get dark
+     text on a dark background during loading (issue #325). */
+  .dark #ap-prerender { color: #e2e8f0; }
+  .dark #ap-prerender .ap-prerender__lead, .dark #ap-prerender .ap-prerender__footer { color: #94a3b8; }
+</style>`
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Structured data: WebPage + Article
+// ───────────────────────────────────────────────────────────────────────────
+const canonical = `${SITE}${PATH}`
+const ogTitle =
+  'Агент создаёт приложение: Интеграм против Retool, Power Platform, NocoDB и Appsmith'
+const ogDescription =
+  'Подробное сравнение Интеграма с лучшими зарубежными low-code платформами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: Retool AI, Power Platform Copilot, NocoDB, Appsmith.'
+const ogImage = `${SITE}/og/knowledge-base.png`
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebPage',
+      '@id': `${canonical}#webpage`,
+      url: canonical,
+      name: ogTitle,
+      description: ogDescription,
+      inLanguage: 'ru',
+      isPartOf: { '@id': `${SITE}/#website` },
+    },
+    {
+      '@type': 'Article',
+      '@id': `${canonical}#article`,
+      headline: ogTitle,
+      description: ogDescription,
+      inLanguage: 'ru',
+      mainEntityOfPage: canonical,
+      url: canonical,
+      image: ogImage,
+      author: { '@id': `${SITE}/#organization` },
+      publisher: { '@id': `${SITE}/#organization` },
+    },
+  ],
+}
+
+const headTags = [
+  `<link rel="canonical" href="${escape(canonical)}" />`,
+  `<meta property="og:type" content="article" />`,
+  `<meta property="og:url" content="${escape(canonical)}" />`,
+  `<meta property="og:title" content="${escape(ogTitle)}" />`,
+  `<meta property="og:description" content="${escape(ogDescription)}" />`,
+  `<meta property="og:image" content="${escape(ogImage)}" />`,
+  `<meta property="og:image:width" content="1200" />`,
+  `<meta property="og:image:height" content="630" />`,
+  `<meta property="og:locale" content="ru_RU" />`,
+  `<meta property="og:site_name" content="${PUBLISHER}" />`,
+  `<meta name="twitter:card" content="summary_large_image" />`,
+  `<meta name="twitter:title" content="${escape(ogTitle)}" />`,
+  `<meta name="twitter:description" content="${escape(ogDescription)}" />`,
+  `<meta name="twitter:image" content="${escape(ogImage)}" />`,
+  `<script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>`,
+].join('\n    ')
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Write dist/agent-platforms.html from the clean SPA shell
+// ───────────────────────────────────────────────────────────────────────────
+const indexPath = resolve(dist, 'index.html')
+const source = readFileSync(indexPath, 'utf8')
+
+if (source.includes('id="lp-prerender"')) {
+  console.error(
+    '✗ prerender-agent-platforms: dist/index.html already carries the landing snapshot — run this BEFORE prerender-landing.mjs',
+  )
+  process.exit(1)
+}
+if (!source.includes('<div id="root"></div>')) {
+  console.error('✗ prerender-agent-platforms: <div id="root"></div> not found in dist/index.html')
+  process.exit(1)
+}
+
+const html = source
+  .replace(/<title>[\s\S]*?<\/title>/, `<title>${escape(ogTitle)}</title>`)
+  .replace(
+    /<meta name="description"[^>]*>/,
+    `<meta name="description" content="${escape(ogDescription)}" />`,
+  )
+  .replace('</head>', `    ${headTags}\n  </head>`)
+  .replace('<div id="root"></div>', `<div id="root">${bodyHtml}</div>`)
+
+const outPath = resolve(dist, 'agent-platforms.html')
+writeFileSync(outPath, html)
+console.log(`✓ agent-platforms prerendered → dist/agent-platforms.html (${html.length} bytes)`)

--- a/src/pages/AgentPlatforms.tsx
+++ b/src/pages/AgentPlatforms.tsx
@@ -21,15 +21,16 @@ import {
   KeyRound,
   FileCode2,
   Sparkles,
+  Building2,
 } from 'lucide-react'
 
 const SITE = 'https://ideav.ru'
 const PATH = '/agent-platforms.html'
 
 const PAGE_TITLE =
-  'Агент создаёт приложение: Интеграм против Retool, Power Platform, NocoDB и Appsmith'
+  'Агент создаёт приложение: Интеграм против зарубежных и российских low-code платформ'
 const PAGE_DESCRIPTION =
-  'Подробное сравнение Интеграма с лучшими зарубежными low-code платформами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: Retool AI, Power Platform Copilot, NocoDB, Appsmith.'
+  'Подробное сравнение Интеграма с low-code платформами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: за рубежом — Retool AI, Power Platform Copilot, NocoDB, Appsmith; в России — Bpium, ELMA365, BPMSoft, AppMaster.'
 
 function setMetaTag(selector: string, attr: 'name' | 'property', key: string, content: string) {
   let el = document.head.querySelector<HTMLMetaElement>(selector)
@@ -173,6 +174,35 @@ const pillars = [
   },
 ]
 
+// Российские low-code/no-code платформы — что умеет ИИ сегодня и где упирается
+// сценарий «агент собирает сервис целиком». Факты по открытым источникам (2025–2026).
+const ruPlatforms = [
+  {
+    name: 'Bpium',
+    what: 'No-code конструктор: таблицы, формы, API, права до уровня поля',
+    ai: 'Приложение собирает человек — ИИ-генерации нет',
+    gap: 'Права настраиваются в интерфейсе',
+  },
+  {
+    name: 'ELMA365',
+    what: 'Low-code экосистема BPM / CRM / КЭДО',
+    ai: 'ИИ-ассистент помогает в визуальном конструкторе',
+    gap: 'Human-in-the-loop',
+  },
+  {
+    name: 'BPMSoft',
+    what: 'Low-code BPM / CRM (замена Creatio), реестр РФ, ФСТЭК',
+    ai: 'LLM-агенты автоматизируют бизнес-процессы',
+    gap: 'Агент — это шаги процесса, не схема и права',
+  },
+  {
+    name: 'AppMaster',
+    what: 'No-code: генерирует исходный код (бэкенд, веб, мобайл)',
+    ai: 'ИИ собирает приложение и API по описанию',
+    gap: 'Реальный код — риск; нет единого админ-API',
+  },
+]
+
 // Полный цикл, который агент проходит без захода в интерфейс.
 const fullCycle = [
   { icon: <Database size={18} />, label: 'Структура базы' },
@@ -191,7 +221,7 @@ export default function AgentPlatforms() {
 
     setMetaTag('meta[name="description"]', 'name', 'description', PAGE_DESCRIPTION)
     setMetaTag('meta[name="keywords"]', 'name', 'keywords',
-      'ии-агент создаёт приложение,low-code,retool ai,power platform copilot,nocodb,appsmith,интеграм,автоматизация без программиста,замена разработчика')
+      'ии-агент создаёт приложение,low-code,no-code,retool ai,power platform copilot,nocodb,appsmith,bpium,elma365,bpmsoft,appmaster,российские low-code платформы,интеграм,автоматизация без программиста,замена разработчика')
     setMetaTag('meta[property="og:type"]', 'property', 'og:type', 'article')
     setMetaTag('meta[property="og:title"]', 'property', 'og:title', PAGE_TITLE)
     setMetaTag('meta[property="og:description"]', 'property', 'og:description', PAGE_DESCRIPTION)
@@ -234,10 +264,9 @@ export default function AgentPlatforms() {
           </motion.h1>
 
           <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed">
-            Подход «приложение полностью собирается ИИ-агентом» — горячий фронт, и за рубежом есть
-            сильные игроки, которые либо уже умеют такое, либо идут к этому семимильными шагами. Ниже —
-            честное сравнение Интеграма с лучшими зарубежными решениями, где агент может выступать
-            разработчиком и администратором.
+            Подход «приложение полностью собирается ИИ-агентом» — горячий фронт, и сильные игроки есть
+            и за рубежом, и в России. Ниже — честное сравнение Интеграма с лучшими решениями обоих
+            рынков, где агент может выступать разработчиком и администратором.
           </p>
         </div>
       </section>
@@ -382,6 +411,61 @@ export default function AgentPlatforms() {
         </div>
       </section>
 
+      {/* Russian analogs */}
+      <section className="py-16 border-t border-slate-200 dark:border-slate-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-2 mb-2">
+            <Building2 size={22} className="text-blue-600 dark:text-blue-400" />
+            <h2 className="text-2xl md:text-3xl font-bold">Российские аналоги</h2>
+          </div>
+          <p className="text-slate-500 dark:text-slate-400 mb-8 max-w-2xl">
+            В России low-code-рынок тоже идёт в ИИ — но по той же модели: ассистент помогает человеку
+            в конструкторе либо агент автоматизирует бизнес-процессы. Полную сборку сервиса агентом не
+            закрывает никто.
+          </p>
+
+          <div className="overflow-x-auto rounded-2xl border border-slate-200 dark:border-slate-800">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="bg-slate-50 dark:bg-slate-900/50">
+                  <th className="text-left py-3 px-4 font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest text-xs">Платформа</th>
+                  <th className="text-left py-3 px-4 font-bold text-slate-500 dark:text-slate-400">Роль ИИ сегодня</th>
+                  <th className="text-left py-3 px-4 font-bold text-amber-600 dark:text-amber-400">Чего нет для «агент делает всё»</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ruPlatforms.map((p, i) => (
+                  <tr key={i} className="border-t border-slate-100 dark:border-slate-800/60 align-top">
+                    <td className="py-3 px-4">
+                      <div className="font-bold text-slate-900 dark:text-white">{p.name}</div>
+                      <div className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{p.what}</div>
+                    </td>
+                    <td className="py-3 px-4 text-slate-600 dark:text-slate-300">{p.ai}</td>
+                    <td className="py-3 px-4">
+                      <span className="inline-flex items-start gap-1.5 text-slate-500 dark:text-slate-400">
+                        <AlertTriangle size={14} className="text-amber-500 shrink-0 mt-0.5" />
+                        {p.gap}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-xs text-slate-400 dark:text-slate-500 mt-3">
+            Visary, SimpleOne, Triafly и другие российские low-code-платформы тоже добавляют ИИ — как
+            ассистентов, а не как самостоятельных сборщиков сервиса.
+          </p>
+
+          <p className="text-slate-600 dark:text-slate-300 leading-relaxed mt-6 max-w-2xl">
+            Полный цикл «структура базы → данные → роли и права → меню → шаблоны» одним идемпотентным
+            API на безопасной EAV-модели — отличие <span className="font-semibold text-blue-600 dark:text-blue-400">Интеграма</span>,
+            к тому же с хостингом в России.
+          </p>
+        </div>
+      </section>
+
       {/* Three pillars */}
       <section className="py-16 border-t border-slate-200 dark:border-slate-900 bg-slate-50/60 dark:bg-slate-900/30">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -413,9 +497,10 @@ export default function AgentPlatforms() {
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-2xl md:text-3xl font-bold mb-4">Вывод</h2>
           <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed mb-4">
-            За рубежом нет точного аналога Интеграма по уровню контроля агента над платформой. Ближайшие
-            конкуренты — Retool, Power Platform, NocoDB, Appsmith — заточены на human-in-the-loop: человек
-            кликает в интерфейсе, агент помогает.
+            Ни за рубежом, ни в России нет точного аналога Интеграма по уровню контроля агента над
+            платформой. Зарубежные (Retool, Power Platform, NocoDB, Appsmith) и российские (Bpium,
+            ELMA365, BPMSoft, AppMaster) решения заточены на human-in-the-loop: человек кликает в
+            интерфейсе, агент помогает.
           </p>
           <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed mb-10">
             Интеграм — платформа, где агент проходит полный цикл: структура базы → наполнение → роли и

--- a/src/pages/AgentPlatforms.tsx
+++ b/src/pages/AgentPlatforms.tsx
@@ -1,0 +1,461 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import {
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  AlertTriangle,
+  Database,
+  Users,
+  ShieldCheck,
+  Code2,
+  Boxes,
+  Repeat,
+  Server,
+  Layers,
+  Globe,
+  Settings2,
+  MousePointerClick,
+  Bot,
+  KeyRound,
+  FileCode2,
+  Sparkles,
+} from 'lucide-react'
+
+const SITE = 'https://ideav.ru'
+const PATH = '/agent-platforms.html'
+
+const PAGE_TITLE =
+  'Агент создаёт приложение: Интеграм против Retool, Power Platform, NocoDB и Appsmith'
+const PAGE_DESCRIPTION =
+  'Подробное сравнение Интеграма с лучшими зарубежными low-code платформами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: Retool AI, Power Platform Copilot, NocoDB, Appsmith.'
+
+function setMetaTag(selector: string, attr: 'name' | 'property', key: string, content: string) {
+  let el = document.head.querySelector<HTMLMetaElement>(selector)
+  if (!el) {
+    el = document.createElement('meta')
+    el.setAttribute(attr, key)
+    document.head.appendChild(el)
+  }
+  el.setAttribute('content', content)
+}
+
+function setCanonical(href: string) {
+  let el = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+  if (!el) {
+    el = document.createElement('link')
+    el.setAttribute('rel', 'canonical')
+    document.head.appendChild(el)
+  }
+  el.setAttribute('href', href)
+}
+
+interface CompareRow {
+  criterion: string
+  them: string
+  us: string
+}
+
+interface Competitor {
+  name: string
+  icon: React.ReactNode
+  what: string
+  agentVerdict: string
+  agentLabel: string
+  limits: string[]
+  rows: CompareRow[]
+}
+
+const competitors: Competitor[] = [
+  {
+    name: 'Retool + Retool AI',
+    icon: <Boxes size={22} />,
+    what: 'Самый близкий аналог по духу — low-code для внутренних инструментов.',
+    agentLabel: 'Агент под ключ: частично',
+    agentVerdict:
+      'Retool AI по текстовому описанию генерирует приложение: создаёт таблицы в подключённой БД (Postgres, MySQL), пишет SQL-запросы и формы, собирает интерфейс из готовых компонентов.',
+    limits: [
+      'Агент не администрирует права доступа и пользователей — это делается в интерфейсе вручную.',
+      'Работает только внутри своей песочницы: нет прямого доступа к файловой системе и системным таблицам.',
+      'Высокая цена, модель только-SaaS.',
+    ],
+    rows: [
+      { criterion: 'Доступ агента к схеме', them: 'Генерация, но без тонкого контроля', us: 'Полный контроль над таблицами, колонками и связями' },
+      { criterion: 'Администрирование ролей', them: 'Нет — только интерфейс', us: 'Полное управление ролями и масками через API' },
+      { criterion: 'Формат шаблонов', them: 'Компоненты Retool (JSON/YAML)', us: 'Чистый HTML / CSS / JS' },
+      { criterion: 'Брендинг и кастомный CSS', them: 'Ограничен темой', us: 'Полная свобода оформления' },
+    ],
+  },
+  {
+    name: 'Microsoft Power Platform + Copilot',
+    icon: <Settings2 size={22} />,
+    what: 'Power Apps (Canvas / Model-driven), Power Automate, Dataverse.',
+    agentLabel: 'Агент под ключ: да, с оговорками',
+    agentVerdict:
+      'Copilot уже умеет по тексту создавать таблицы Dataverse, связи и колонки, собирать Canvas-приложения с формами и галереями, строить потоки Power Automate для логики.',
+    limits: [
+      'Агент не вызывает системные API для управления ролями безопасности — это делается через сложный интерфейс Business Units.',
+      'Кастомизация интерфейса слабее: Copilot собирает из готовых блоков, заменить их на чистый HTML/JS нельзя.',
+      'Входной барьер: нужна лицензия Power Apps Premium (≈ $20 за пользователя в месяц).',
+    ],
+    rows: [
+      { criterion: 'Контроль схемы', them: 'Генерация, но без API для агента', us: 'Полный API: метаданные, связи, псевдонимы' },
+      { criterion: 'Ролевая модель', them: 'Сложная, без API для агента', us: 'Простая и скриптуемая' },
+      { criterion: 'Программный доступ', them: 'PowerShell / CLI (неполный)', us: 'Обычный curl + токен авторизации' },
+      { criterion: 'Вендор-лок', them: 'Полный (Azure AD + Dataverse)', us: 'Открытый — ideav.ru или свой сервер' },
+    ],
+  },
+  {
+    name: 'NocoDB',
+    icon: <Database size={22} />,
+    what: 'Open-source low-code платформа, «умная таблица» поверх SQL.',
+    agentLabel: 'Агент под ключ: через REST API',
+    agentVerdict:
+      'Агент создаёт таблицы, колонки и связи по HTTP, управляет правами и ролями (есть API для пользователей и команд), генерирует формы и виды (Grid, Form, Gallery). Open-source — агент может читать исходный код.',
+    limits: [
+      'Нет песочницы поверх единой модели: изменения затрагивают реальные SQL-таблицы — рискованно для автономного агента.',
+      'Агент может удалить колонку с данными при ошибке.',
+      'Нет встроенного серверного рендеринга шаблонов.',
+    ],
+    rows: [
+      { criterion: 'API для агента', them: 'Полный REST', us: 'Полный REST' },
+      { criterion: 'Модель данных', them: 'Прямой SQL — риск для агента', us: 'EAV — агент не сломает структуру' },
+      { criterion: 'Шаблоны и интерфейс', them: 'Готовые виды (Grid, Form)', us: 'Чистый HTML / CSS / JS' },
+      { criterion: 'Российский хостинг', them: 'Зарубежный / свой VPS', us: 'ideav.ru — сервер в РФ' },
+    ],
+  },
+  {
+    name: 'Appsmith',
+    icon: <Code2 size={22} />,
+    what: 'Open-source low-code для внутренних инструментов, близок к Retool.',
+    agentLabel: 'Агент под ключ: через Git + API',
+    agentVerdict:
+      'Агент редактирует JSON-представление приложения и коммитит в Git, создаёт источники данных, запросы и страницы через API. Полное GitOps-управление подходит для CI/CD-пайплайнов агента.',
+    limits: [
+      'Агент не управляет пользователями и ролями на уровне Интеграма — это делается через интерфейс.',
+      'Нет единой модели данных: агент должен знать SQL-схему и быть осторожным.',
+    ],
+    rows: [
+      { criterion: 'Подход агента', them: 'Git + JSON/YAML', us: 'Прямые вызовы API' },
+      { criterion: 'Управление схемой', them: 'Через SQL — агент должен знать БД', us: 'EAV — всё единообразно' },
+      { criterion: 'Роли и права', them: 'Только интерфейс', us: 'Полный API: роли и маски' },
+      { criterion: 'Кастомизация интерфейса', them: 'Виджеты Appsmith', us: 'Чистый HTML / JS' },
+    ],
+  },
+]
+
+const pillars = [
+  {
+    icon: <Boxes size={24} />,
+    title: 'Единая модель данных (EAV)',
+    body: 'Все данные — в одной физической таблице. Ошибка агента создаст новый тип, а не разрушит структуру. В NocoDB или Appsmith неосторожный агент может удалить колонку с данными.',
+  },
+  {
+    icon: <Layers size={24} />,
+    title: 'Единый API для всего',
+    body: 'Пользователи, роли, таблицы, колонки и связи — через одни и те же вызовы. Агенту не нужно переключаться между REST, SQL и проприетарными SDK.',
+  },
+  {
+    icon: <KeyRound size={24} />,
+    title: 'Сквозные права и маски через API',
+    body: 'У конкурентов права настраиваются в интерфейсе. В Интеграме агент сам пишет правила доступа с уровнями и масками по пользователю. Ролевая модель полностью управляется скриптом.',
+  },
+  {
+    icon: <FileCode2 size={24} />,
+    title: 'Чистые HTML/JS-шаблоны',
+    body: 'Агент генерирует интерфейс напрямую, без привязки к проприетарным виджетам. Это даёт абсолютную гибкость брендинга.',
+  },
+  {
+    icon: <Repeat size={24} />,
+    title: 'Идемпотентные вызовы',
+    body: 'Повторный вызов не падает с ошибкой, а возвращает существующий идентификатор. Агент запускает скрипты повторно без сложной логики откатов.',
+  },
+]
+
+// Полный цикл, который агент проходит без захода в интерфейс.
+const fullCycle = [
+  { icon: <Database size={18} />, label: 'Структура базы' },
+  { icon: <Boxes size={18} />, label: 'Наполнение данными' },
+  { icon: <KeyRound size={18} />, label: 'Роли и права' },
+  { icon: <Layers size={18} />, label: 'Меню и навигация' },
+  { icon: <FileCode2 size={18} />, label: 'Шаблоны интерфейса' },
+  { icon: <Sparkles size={18} />, label: 'Тестовые данные' },
+]
+
+export default function AgentPlatforms() {
+  useEffect(() => {
+    document.title = PAGE_TITLE
+    const canonical = `${SITE}${PATH}`
+    const ogImage = `${SITE}/og/knowledge-base.png`
+
+    setMetaTag('meta[name="description"]', 'name', 'description', PAGE_DESCRIPTION)
+    setMetaTag('meta[name="keywords"]', 'name', 'keywords',
+      'ии-агент создаёт приложение,low-code,retool ai,power platform copilot,nocodb,appsmith,интеграм,автоматизация без программиста,замена разработчика')
+    setMetaTag('meta[property="og:type"]', 'property', 'og:type', 'article')
+    setMetaTag('meta[property="og:title"]', 'property', 'og:title', PAGE_TITLE)
+    setMetaTag('meta[property="og:description"]', 'property', 'og:description', PAGE_DESCRIPTION)
+    setMetaTag('meta[property="og:url"]', 'property', 'og:url', canonical)
+    setMetaTag('meta[property="og:image"]', 'property', 'og:image', ogImage)
+    setMetaTag('meta[property="og:site_name"]', 'property', 'og:site_name', 'Интеграм')
+    setMetaTag('meta[property="og:locale"]', 'property', 'og:locale', 'ru_RU')
+    setMetaTag('meta[name="twitter:card"]', 'name', 'twitter:card', 'summary_large_image')
+    setMetaTag('meta[name="twitter:title"]', 'name', 'twitter:title', PAGE_TITLE)
+    setMetaTag('meta[name="twitter:description"]', 'name', 'twitter:description', PAGE_DESCRIPTION)
+    setMetaTag('meta[name="twitter:image"]', 'name', 'twitter:image', ogImage)
+    setCanonical(canonical)
+  }, [])
+
+  return (
+    <div className="overflow-hidden">
+      {/* Hero */}
+      <section className="pt-28 pb-12 lg:pt-36 lg:pb-16 border-b border-slate-200 dark:border-slate-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Link
+            to="/excel-to-app.html"
+            className="inline-flex items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
+          >
+            <ArrowLeft size={16} /> Назад к «Excel → приложение»
+          </Link>
+
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-5">
+            <Bot size={14} />
+            Агент как полноценный разработчик
+          </div>
+
+          <motion.h1
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight mb-5"
+          >
+            Сервис целиком создаёт и администрирует агент —{' '}
+            <span className="text-blue-500">кто это уже умеет</span>
+          </motion.h1>
+
+          <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed">
+            Подход «приложение полностью собирается ИИ-агентом» — горячий фронт, и за рубежом есть
+            сильные игроки, которые либо уже умеют такое, либо идут к этому семимильными шагами. Ниже —
+            честное сравнение Интеграма с лучшими зарубежными решениями, где агент может выступать
+            разработчиком и администратором.
+          </p>
+        </div>
+      </section>
+
+      {/* Illustration 1 — full cycle */}
+      <section className="py-14 border-b border-slate-200 dark:border-slate-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-2xl md:text-3xl font-bold mb-2">Полный цикл — без единого клика в интерфейсе</h2>
+          <p className="text-slate-500 dark:text-slate-400 mb-8 max-w-2xl">
+            В Интеграме агент проходит весь путь от пустой базы до рабочего приложения одними и теми же
+            API-вызовами:
+          </p>
+
+          <div className="flex flex-wrap items-stretch gap-3">
+            {fullCycle.map((step, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <div className="flex items-center gap-2.5 px-4 py-3 rounded-2xl border border-blue-200 dark:border-blue-900/40 bg-blue-50/60 dark:bg-blue-950/30">
+                  <span className="text-blue-600 dark:text-blue-400">{step.icon}</span>
+                  <span className="text-sm font-semibold text-slate-800 dark:text-slate-100 whitespace-nowrap">
+                    {step.label}
+                  </span>
+                </div>
+                {i < fullCycle.length - 1 && (
+                  <ArrowRight size={16} className="text-slate-300 dark:text-slate-600 shrink-0" />
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Illustration 2 — two approaches */}
+      <section className="py-14 border-b border-slate-200 dark:border-slate-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-2xl md:text-3xl font-bold mb-8">Два подхода к роли агента</h2>
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* Human-in-the-loop */}
+            <div className="p-6 rounded-3xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950">
+              <div className="flex items-center gap-2 mb-4">
+                <MousePointerClick size={20} className="text-amber-500" />
+                <h3 className="text-lg font-bold">Human-in-the-loop</h3>
+              </div>
+              <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+                Retool, Power Apps, Appsmith: человек кликает в интерфейсе, агент помогает.
+              </p>
+              <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                <li className="flex items-start gap-2"><AlertTriangle size={16} className="text-amber-500 shrink-0 mt-0.5" /> Права и роли — вручную в интерфейсе</li>
+                <li className="flex items-start gap-2"><AlertTriangle size={16} className="text-amber-500 shrink-0 mt-0.5" /> Интерфейс — из готовых виджетов</li>
+                <li className="flex items-start gap-2"><AlertTriangle size={16} className="text-amber-500 shrink-0 mt-0.5" /> Часть шагов остаётся на человеке</li>
+              </ul>
+            </div>
+
+            {/* Agent full cycle */}
+            <div className="p-6 rounded-3xl border border-blue-300 dark:border-blue-900/50 bg-gradient-to-b from-blue-50 to-white dark:from-blue-950/40 dark:to-slate-950">
+              <div className="flex items-center gap-2 mb-4">
+                <Bot size={20} className="text-blue-500" />
+                <h3 className="text-lg font-bold">Агент полного цикла</h3>
+              </div>
+              <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+                Интеграм: агент выполняет весь цикл сам, без захода в интерфейс.
+              </p>
+              <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                <li className="flex items-start gap-2"><CheckCircle2 size={16} className="text-blue-500 shrink-0 mt-0.5" /> Роли и маски — скриптом через API</li>
+                <li className="flex items-start gap-2"><CheckCircle2 size={16} className="text-blue-500 shrink-0 mt-0.5" /> Интерфейс — чистый HTML/JS</li>
+                <li className="flex items-start gap-2"><CheckCircle2 size={16} className="text-blue-500 shrink-0 mt-0.5" /> Структура → данные → права → шаблоны</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Competitors */}
+      <section className="py-16">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-2xl md:text-3xl font-bold mb-2">Главные зарубежные конкуренты</h2>
+          <p className="text-slate-500 dark:text-slate-400 mb-10 max-w-2xl">
+            По модели «агент создаёт приложение» — что они умеют, где упираются и чем отличается Интеграм.
+          </p>
+
+          <div className="space-y-12">
+            {competitors.map((c, idx) => (
+              <article key={idx} className="scroll-mt-24">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="w-11 h-11 rounded-2xl bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 flex items-center justify-center shrink-0">
+                    {c.icon}
+                  </div>
+                  <div>
+                    <h3 className="text-xl font-bold leading-tight">{c.name}</h3>
+                    <p className="text-sm text-slate-500 dark:text-slate-400">{c.what}</p>
+                  </div>
+                </div>
+
+                <div className="inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/40 px-2.5 py-1 rounded-lg mb-3">
+                  <CheckCircle2 size={14} />
+                  {c.agentLabel}
+                </div>
+                <p className="text-slate-600 dark:text-slate-300 leading-relaxed mb-4">{c.agentVerdict}</p>
+
+                <div className="mb-5">
+                  <div className="text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2">
+                    Ограничения
+                  </div>
+                  <ul className="space-y-1.5">
+                    {c.limits.map((l, i) => (
+                      <li key={i} className="flex items-start gap-2 text-sm text-slate-600 dark:text-slate-300">
+                        <AlertTriangle size={15} className="text-amber-500 shrink-0 mt-0.5" />
+                        {l}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                {/* Comparison table vs Integram */}
+                <div className="overflow-x-auto rounded-2xl border border-slate-200 dark:border-slate-800">
+                  <table className="w-full border-collapse text-sm">
+                    <thead>
+                      <tr className="bg-slate-50 dark:bg-slate-900/50">
+                        <th className="text-left py-3 px-4 font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest text-xs">Критерий</th>
+                        <th className="text-left py-3 px-4 font-bold text-slate-500 dark:text-slate-400">{c.name.split(' ')[0]}</th>
+                        <th className="text-left py-3 px-4 font-bold text-blue-600 dark:text-blue-400">Интеграм</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {c.rows.map((r, i) => (
+                        <tr key={i} className="border-t border-slate-100 dark:border-slate-800/60">
+                          <td className="py-3 px-4 font-medium text-slate-900 dark:text-white">{r.criterion}</td>
+                          <td className="py-3 px-4 text-slate-500 dark:text-slate-400">{r.them}</td>
+                          <td className="py-3 px-4 text-slate-700 dark:text-slate-200">
+                            <span className="inline-flex items-start gap-1.5">
+                              <CheckCircle2 size={14} className="text-blue-500 shrink-0 mt-0.5" />
+                              {r.us}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Three pillars */}
+      <section className="py-16 border-t border-slate-200 dark:border-slate-900 bg-slate-50/60 dark:bg-slate-900/30">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <h2 className="text-2xl md:text-3xl font-bold mb-3">Чем Интеграм уникален для полной автоматизации</h2>
+            <p className="text-slate-600 dark:text-slate-300 max-w-2xl mx-auto">
+              Пять опор, которые позволяют агенту собрать сервис целиком — без участия человека в интерфейсе.
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {pillars.map((p, i) => (
+              <div
+                key={i}
+                className="p-7 rounded-3xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 shadow-sm dark:shadow-none"
+              >
+                <div className="w-12 h-12 rounded-2xl bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 flex items-center justify-center mb-4">
+                  {p.icon}
+                </div>
+                <h3 className="text-lg font-bold mb-2">{p.title}</h3>
+                <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">{p.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Conclusion + CTA */}
+      <section className="py-16">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-2xl md:text-3xl font-bold mb-4">Вывод</h2>
+          <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed mb-4">
+            За рубежом нет точного аналога Интеграма по уровню контроля агента над платформой. Ближайшие
+            конкуренты — Retool, Power Platform, NocoDB, Appsmith — заточены на human-in-the-loop: человек
+            кликает в интерфейсе, агент помогает.
+          </p>
+          <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed mb-10">
+            Интеграм — платформа, где агент проходит полный цикл: структура базы → наполнение → роли и
+            права → меню → шаблоны → тестовые данные, и всё это единообразными API-вызовами без захода
+            в интерфейс.
+          </p>
+
+          <div className="rounded-3xl border border-blue-500/30 bg-gradient-to-b from-blue-50 to-white dark:from-blue-950/40 dark:to-slate-950 p-8 text-center">
+            <div className="flex justify-center mb-4">
+              <div className="w-14 h-14 rounded-2xl bg-blue-600 text-white flex items-center justify-center">
+                <Sparkles size={26} />
+              </div>
+            </div>
+            <h3 className="text-xl md:text-2xl font-bold mb-3">Проверьте на своих данных</h3>
+            <p className="text-slate-600 dark:text-slate-300 mb-6 max-w-xl mx-auto">
+              Загрузите свои Excel-таблицы — агент соберёт работающее приложение примерно за 45 минут.
+            </p>
+            <Link
+              to="/excel-to-app.html#excel-form"
+              className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl shadow-lg shadow-blue-600/20 transition-colors"
+            >
+              Загрузить Excel и получить приложение
+              <ArrowRight size={18} />
+            </Link>
+          </div>
+
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-slate-400 dark:text-slate-500">
+            <span className="inline-flex items-center gap-1.5"><Server size={14} /> Сервер в РФ — ideav.ru</span>
+            <span className="inline-flex items-center gap-1.5"><ShieldCheck size={14} /> Ваши данные принадлежат вам</span>
+            <span className="inline-flex items-center gap-1.5"><Users size={14} /> Роли и права из коробки</span>
+            <span className="inline-flex items-center gap-1.5"><Globe size={14} /> Без вендор-лока</span>
+          </div>
+
+          <p className="mt-10 text-center text-sm">
+            <Link to="/knowledge-base.html" className="text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors">
+              Ещё сравнения — в базе знаний →
+            </Link>
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/ExcelToApp.tsx
+++ b/src/pages/ExcelToApp.tsx
@@ -967,13 +967,13 @@ export default function ExcelToApp() {
           <div className="text-center mb-10">
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-4">
               <Sparkles size={14} />
-              Интеграм и зарубежные платформы
+              Интеграм и аналоги
             </div>
             <h2 className="text-2xl md:text-3xl font-bold mb-3">А что у конкурентов?</h2>
             <p className="text-slate-600 dark:text-slate-300 max-w-2xl mx-auto">
-              За рубежом приложение тоже умеют собирать ИИ-агентом — Retool, Power Apps, NocoDB,
-              Appsmith. Но почти везде человек всё равно доделывает руками в интерфейсе. У Интеграма
-              агент проходит весь путь сам.
+              Приложение умеют собирать ИИ-агентом и за рубежом (Retool, Power Apps, NocoDB, Appsmith),
+              и в России (Bpium, ELMA365, BPMSoft). Но почти везде человек всё равно доделывает руками
+              в интерфейсе. У Интеграма агент проходит весь путь сам.
             </p>
           </div>
 
@@ -1009,7 +1009,7 @@ export default function ExcelToApp() {
               to="/agent-platforms.html"
               className="inline-flex items-center gap-2 px-5 py-3 rounded-xl border border-blue-500/40 text-blue-600 dark:text-blue-400 font-semibold hover:bg-blue-50 dark:hover:bg-blue-950/30 transition-colors"
             >
-              Подробный разбор: Интеграм против Retool, Power Platform, NocoDB и Appsmith
+              Подробный разбор: Интеграм против зарубежных и российских платформ
               <ArrowRight size={18} />
             </Link>
           </div>

--- a/src/pages/ExcelToApp.tsx
+++ b/src/pages/ExcelToApp.tsx
@@ -364,6 +364,31 @@ export default function ExcelToApp() {
     },
   ]
 
+  // Сравнение языком бизнеса с зарубежными low-code платформами,
+  // где приложение тоже собирает ИИ-агент. Подробности — на /agent-platforms.html.
+  const agentCompare = [
+    {
+      label: 'Кто настраивает права доступа',
+      integram: 'Агент — сам, по описанию',
+      world: 'Человек вручную в интерфейсе',
+    },
+    {
+      label: 'Интерфейс под ваш бренд',
+      integram: 'Чистый HTML/CSS без ограничений',
+      world: 'Готовые виджеты платформы',
+    },
+    {
+      label: 'Где лежат данные',
+      integram: 'Сервер в России — ideav.ru',
+      world: 'Зарубежный хостинг',
+    },
+    {
+      label: 'Привязка к вендору',
+      integram: 'Нет — можно свой сервер',
+      world: 'Высокая',
+    },
+  ]
+
   return (
     <div className="overflow-hidden">
       {/* Payment offer */}
@@ -935,6 +960,61 @@ export default function ExcelToApp() {
           — от 1950 рублей в месяц.
         </p>
       </div>
+
+      {/* Comparison with foreign agent-platforms (business language) */}
+      <section className="py-16 border-t border-slate-200 dark:border-slate-900 bg-slate-50/60 dark:bg-slate-900/30">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-10">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-4">
+              <Sparkles size={14} />
+              Интеграм и зарубежные платформы
+            </div>
+            <h2 className="text-2xl md:text-3xl font-bold mb-3">А что у конкурентов?</h2>
+            <p className="text-slate-600 dark:text-slate-300 max-w-2xl mx-auto">
+              За рубежом приложение тоже умеют собирать ИИ-агентом — Retool, Power Apps, NocoDB,
+              Appsmith. Но почти везде человек всё равно доделывает руками в интерфейсе. У Интеграма
+              агент проходит весь путь сам.
+            </p>
+          </div>
+
+          <div className="grid gap-3 sm:gap-4 max-w-2xl mx-auto">
+            {agentCompare.map((row, i) => (
+              <div
+                key={i}
+                className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-4 sm:p-5"
+              >
+                <div className="text-sm font-bold text-slate-900 dark:text-white mb-3">{row.label}</div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <div className="flex items-start gap-2">
+                    <CheckCircle2 size={16} className="text-blue-500 shrink-0 mt-0.5" />
+                    <span className="text-sm text-slate-700 dark:text-slate-200">
+                      <span className="font-semibold text-blue-600 dark:text-blue-400">Интеграм:</span>{' '}
+                      {row.integram}
+                    </span>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <AlertTriangle size={16} className="text-amber-500 shrink-0 mt-0.5" />
+                    <span className="text-sm text-slate-500 dark:text-slate-400">
+                      <span className="font-semibold text-amber-600 dark:text-amber-400">Зарубежные:</span>{' '}
+                      {row.world}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="text-center mt-8">
+            <Link
+              to="/agent-platforms.html"
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-xl border border-blue-500/40 text-blue-600 dark:text-blue-400 font-semibold hover:bg-blue-50 dark:hover:bg-blue-950/30 transition-colors"
+            >
+              Подробный разбор: Интеграм против Retool, Power Platform, NocoDB и Appsmith
+              <ArrowRight size={18} />
+            </Link>
+          </div>
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,6 +4,7 @@ import NotFound from './pages/NotFound'
 import Success from './pages/Success'
 import Fail from './pages/Fail'
 import ExcelToApp from './pages/ExcelToApp'
+import AgentPlatforms from './pages/AgentPlatforms'
 import Tokens from './pages/Tokens'
 import AdImages from './pages/AdImages'
 import KnowledgeBase from './pages/KnowledgeBase'
@@ -30,6 +31,14 @@ export const router = createBrowserRouter([
       {
         path: 'excel-to-app.html',
         element: <ExcelToApp />,
+      },
+      {
+        path: 'agent-platforms.html',
+        element: <AgentPlatforms />,
+      },
+      {
+        path: 'agent-platforms',
+        element: <AgentPlatforms />,
       },
       {
         path: 'tokens.html',

--- a/tests/issue-360-agent-platforms.test.mjs
+++ b/tests/issue-360-agent-platforms.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, cpSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+const repo = new URL('..', import.meta.url).pathname
+const read = (p) => readFileSync(resolve(repo, p), 'utf8')
+
+const pageSource = read('src/pages/AgentPlatforms.tsx')
+const excelSource = read('src/pages/ExcelToApp.tsx')
+const routerSource = read('src/router.tsx')
+const sitemapSource = read('public/sitemap.xml')
+const indexHtml = read('index.html')
+
+function makeWorkspace(prefix) {
+  const work = mkdtempSync(resolve(tmpdir(), prefix))
+  mkdirSync(resolve(work, 'dist'), { recursive: true })
+  mkdirSync(resolve(work, 'scripts'), { recursive: true })
+  cpSync(resolve(repo, 'scripts/prerender-agent-platforms.mjs'), resolve(work, 'scripts/prerender-agent-platforms.mjs'))
+  cpSync(resolve(repo, 'scripts/prerender-landing.mjs'), resolve(work, 'scripts/prerender-landing.mjs'))
+  writeFileSync(resolve(work, 'dist/index.html'), indexHtml)
+  return work
+}
+
+test('the /agent-platforms.html route is registered and renders AgentPlatforms', () => {
+  assert.match(routerSource, /import AgentPlatforms from '\.\/pages\/AgentPlatforms'/)
+  assert.match(
+    routerSource,
+    /path:\s*'agent-platforms\.html',\s*\n\s*element:\s*<AgentPlatforms \/>/,
+    'router should map agent-platforms.html to <AgentPlatforms />',
+  )
+  assert.match(routerSource, /path:\s*'agent-platforms',\s*\n\s*element:\s*<AgentPlatforms \/>/)
+})
+
+test('the detailed page covers all four foreign competitors and the Integram pillars', () => {
+  assert.match(pageSource, /Retool/)
+  assert.match(pageSource, /Power Platform/)
+  assert.match(pageSource, /NocoDB/)
+  assert.match(pageSource, /Appsmith/)
+  // Unique-advantage pillars (business framing, no raw API identifiers).
+  assert.match(pageSource, /Единая модель данных/)
+  assert.match(pageSource, /Единый API для всего/)
+  assert.match(pageSource, /Идемпотентные вызовы/)
+  // A couple of illustrations: the full agent cycle and the two-approaches diagram.
+  assert.match(pageSource, /Полный цикл/)
+  assert.match(pageSource, /Human-in-the-loop/)
+  assert.match(pageSource, /Агент полного цикла/)
+})
+
+test('the detailed page sets its own SEO title, description and canonical', () => {
+  assert.match(pageSource, /document\.title = PAGE_TITLE/)
+  assert.match(pageSource, /const canonical = `\$\{SITE\}\$\{PATH\}`/)
+  assert.match(pageSource, /setCanonical\(canonical\)/)
+  assert.match(pageSource, /const PATH = '\/agent-platforms\.html'/)
+})
+
+test('the Excel→app landing ends with a compact comparison linking to the detailed page', () => {
+  // Business-language comparison block.
+  assert.match(excelSource, /А что у конкурентов\?/)
+  assert.match(excelSource, /const agentCompare = \[/)
+  // Prominent link to the detailed analysis.
+  assert.match(
+    excelSource,
+    /to="\/agent-platforms\.html"/,
+    'the landing must link to the detailed comparison page',
+  )
+  assert.match(excelSource, /Подробный разбор/)
+})
+
+test('build pipeline runs the agent-platforms prerender after excel-to-app and before landing', () => {
+  const pkg = JSON.parse(read('package.json'))
+  const build = pkg.scripts.build
+  assert.match(build, /prerender-agent-platforms\.mjs/)
+  assert.ok(
+    build.indexOf('prerender-excel-to-app.mjs') < build.indexOf('prerender-agent-platforms.mjs'),
+    'agent-platforms prerender must run after the excel-to-app prerender',
+  )
+  assert.ok(
+    build.indexOf('prerender-agent-platforms.mjs') < build.indexOf('prerender-landing.mjs'),
+    'agent-platforms prerender must run before the landing prerender (clean index.html template)',
+  )
+})
+
+test('prerender-agent-platforms writes a crawlable dist/agent-platforms.html', () => {
+  const work = makeWorkspace('ap-prerender-')
+
+  execFileSync('node', ['scripts/prerender-agent-platforms.mjs'], { cwd: work })
+
+  const outPath = resolve(work, 'dist/agent-platforms.html')
+  assert.ok(existsSync(outPath), 'dist/agent-platforms.html must be created')
+  const out = readFileSync(outPath, 'utf8')
+
+  // #root carries a crawlable H1 and competitor headings.
+  assert.doesNotMatch(out, /<div id="root"><\/div>/, '#root must not be left empty')
+  assert.match(out, /<div id="root">\s*<article id="ap-prerender"/)
+  assert.match(out, /Retool \+ Retool AI/)
+  assert.match(out, /Microsoft Power Platform \+ Copilot/)
+  assert.match(out, /NocoDB/)
+  assert.match(out, /Appsmith/)
+
+  // SEO head tags: canonical, Open Graph, Article JSON-LD, tightened title.
+  assert.match(out, /<link rel="canonical" href="https:\/\/ideav\.ru\/agent-platforms\.html" \/>/)
+  assert.match(out, /<title>Агент создаёт приложение[^<]*<\/title>/)
+  assert.match(out, /<meta property="og:title"/)
+  assert.match(out, /application\/ld\+json/)
+  assert.match(out, /"@type":"Article"/)
+})
+
+test('prerender-agent-platforms does not mutate dist/index.html (home page)', () => {
+  const work = makeWorkspace('ap-prerender-home-')
+  const before = readFileSync(resolve(work, 'dist/index.html'), 'utf8')
+  execFileSync('node', ['scripts/prerender-agent-platforms.mjs'], { cwd: work })
+  const after = readFileSync(resolve(work, 'dist/index.html'), 'utf8')
+  assert.equal(before, after, 'the home page shell must stay untouched')
+})
+
+test('prerender-agent-platforms refuses to run after the landing prerender patched index.html', () => {
+  const work = makeWorkspace('ap-prerender-order-')
+  execFileSync('node', ['scripts/prerender-landing.mjs'], { cwd: work })
+  assert.throws(
+    () => execFileSync('node', ['scripts/prerender-agent-platforms.mjs'], { cwd: work, stdio: 'pipe' }),
+    /Command failed/,
+    'running after the landing prerender must fail loudly',
+  )
+})
+
+test('the agent-platforms page is listed in the sitemap', () => {
+  assert.match(sitemapSource, /<loc>https:\/\/ideav\.ru\/agent-platforms\.html<\/loc>/)
+})

--- a/tests/issue-360-agent-platforms.test.mjs
+++ b/tests/issue-360-agent-platforms.test.mjs
@@ -75,6 +75,8 @@ test('the Excel→app landing ends with a compact comparison linking to the deta
     'the landing must link to the detailed comparison page',
   )
   assert.match(excelSource, /Подробный разбор/)
+  // Mini-mention of Russian analogs, not just foreign ones.
+  assert.match(excelSource, /Bpium/)
 })
 
 test('build pipeline runs the agent-platforms prerender after excel-to-app and before landing', () => {

--- a/tests/issue-360-agent-platforms.test.mjs
+++ b/tests/issue-360-agent-platforms.test.mjs
@@ -49,6 +49,14 @@ test('the detailed page covers all four foreign competitors and the Integram pil
   assert.match(pageSource, /Агент полного цикла/)
 })
 
+test('the detailed page covers Russian low-code analogs', () => {
+  assert.match(pageSource, /Российские аналоги/)
+  assert.match(pageSource, /Bpium/)
+  assert.match(pageSource, /ELMA365/)
+  assert.match(pageSource, /BPMSoft/)
+  assert.match(pageSource, /AppMaster/)
+})
+
 test('the detailed page sets its own SEO title, description and canonical', () => {
   assert.match(pageSource, /document\.title = PAGE_TITLE/)
   assert.match(pageSource, /const canonical = `\$\{SITE\}\$\{PATH\}`/)
@@ -99,6 +107,11 @@ test('prerender-agent-platforms writes a crawlable dist/agent-platforms.html', (
   assert.match(out, /Microsoft Power Platform \+ Copilot/)
   assert.match(out, /NocoDB/)
   assert.match(out, /Appsmith/)
+
+  // Russian analogs section is crawlable too.
+  assert.match(out, /Российские аналоги/)
+  assert.match(out, /Bpium/)
+  assert.match(out, /BPMSoft/)
 
   // SEO head tags: canonical, Open Graph, Article JSON-LD, tightened title.
   assert.match(out, /<link rel="canonical" href="https:\/\/ideav\.ru\/agent-platforms\.html" \/>/)


### PR DESCRIPTION
Закрывает #360.

## Что сделано

**1. Компактный блок в конце `excel-to-app.html` — языком бизнеса.**
Секция «А что у конкурентов?»: 4 карточки-сравнения Интеграм vs зарубежные платформы (кто настраивает права доступа, брендинг интерфейса, где лежат данные, привязка к вендору).

**2. Ссылка на подробный разбор.**
Заметная кнопка «Подробный разбор: Интеграм против Retool, Power Platform, NocoDB и Appsmith →».

**3. Отдельная страница `/agent-platforms.html`** (`src/pages/AgentPlatforms.tsx`).
Полное сравнение по модели «агент создаёт приложение под ключ»: Retool AI, Power Platform Copilot, NocoDB, Appsmith — что умеют, ограничения и таблица отличий от Интеграма по каждому. Пять «опор» уникальности и вывод с CTA. **Две иллюстрации:** полный цикл агента (структура → данные → права → меню → шаблоны → тестовые данные) и «human-in-the-loop vs агент полного цикла».

## Инфраструктура
- `router.tsx` — маршруты `agent-platforms.html` и `agent-platforms`
- `scripts/prerender-agent-platforms.mjs` — статический SEO-снимок (canonical, OG/Twitter, JSON-LD WebPage+Article, crawlable-фолбэк в `#root`); подключён в `build` после excel-to-app и перед landing (читает чистый `dist/index.html`)
- `public/sitemap.xml` — новый URL
- `tests/issue-360-agent-platforms.test.mjs` — маршрут, контент, ссылка с лендинга, prerender, порядок в build, sitemap

## Проверки
- `tsc --noEmit` — чисто
- `npm run build` — проходит, `dist/agent-platforms.html` генерируется в правильном порядке
- Новые тесты 9/9 зелёные
- Визуальная проверка в браузере (светлая/тёмная темы, 0 ошибок в консоли)

🤖 Generated with [Claude Code](https://claude.com/claude-code)