### PR TITLE
revert(#323): вернуть ссылки на «Excel → приложение» на главной

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,7 @@ export function Header() {
   const { theme, toggleTheme } = useTheme()
 
   const navLinks = [
+    { name: 'Excel → приложение', href: '/excel-to-app.html' },
     { name: 'Технология', href: '/#technology' },
     { name: 'Как работаем', href: '/#process' },
     { name: 'Примеры', href: '/#cases' },

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -33,8 +33,10 @@ import {
   Wrench,
   Sparkles,
   Briefcase,
-  ServerCog
+  ServerCog,
+  FileSpreadsheet
 } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import ClientLogos from '@/components/ClientLogos'
 
 declare global {
@@ -242,7 +244,38 @@ export default function Home() {
         </div>
       </section>
 
-      {/* 1b. Excel → app promo (temporarily hidden per issue #323) */}
+      {/* 1b. Excel → app promo */}
+      <section className="py-12 border-t border-slate-200 dark:border-slate-900">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Link
+            to="/excel-to-app.html"
+            className="group grid lg:grid-cols-[auto_1fr_auto] items-center gap-6 p-6 sm:p-8 rounded-3xl border border-blue-200 dark:border-blue-900/60 bg-gradient-to-r from-blue-50 to-white dark:from-blue-950/40 dark:to-slate-950 hover:border-blue-400 dark:hover:border-blue-700 transition-colors"
+          >
+            <div className="w-14 h-14 rounded-2xl bg-blue-600/10 text-blue-600 dark:text-blue-400 flex items-center justify-center shrink-0">
+              <FileSpreadsheet size={26} />
+            </div>
+            <div>
+              <div className="text-xs font-bold text-blue-600 dark:text-blue-400 uppercase tracking-widest mb-1">
+                Новое · готово за ~45 минут
+              </div>
+              <h2 className="text-2xl md:text-3xl font-bold mb-1">
+                Загрузите Excel — получите приложение
+              </h2>
+              <p className="text-slate-500 dark:text-slate-400">
+                Пришлите свои таблицы и тематику — вернём ссылку на готовую базу Интеграм с вашими данными.
+              </p>
+            </div>
+            <span className="hidden lg:inline-flex items-center gap-2 px-6 py-3 bg-blue-600 group-hover:bg-blue-700 text-white font-bold rounded-xl shadow-lg shadow-blue-600/20 transition-colors shrink-0">
+              Загрузить файлы
+              <ArrowRight size={18} className="group-hover:translate-x-1 transition-transform" />
+            </span>
+            <span className="lg:hidden inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 font-bold">
+              Загрузить файлы
+              <ArrowRight size={18} className="group-hover:translate-x-1 transition-transform" />
+            </span>
+          </Link>
+        </div>
+      </section>
 
       {/* 2. Problem Section */}
       <section className="py-24 bg-slate-50 dark:bg-slate-900/50 relative">


### PR DESCRIPTION
Возвращает на главную ссылки на лендинг «Excel → приложение», скрытые в #324 как временные.

## Что изменено
Откат скрытия из PR #324 (issue #323):

- **Шапка** (`src/components/Header.tsx`) — снова показываем nav-ссылку «Excel → приложение» → `/excel-to-app.html` (первым пунктом меню, как было).
- **Главная** (`src/pages/Home.tsx`) — возвращён промо-блок «Загрузите Excel — получите приложение» между hero и блоком «Проблема»; восстановлены импорты `Link` и `FileSpreadsheet`.

Страница и маршрут `/excel-to-app.html` не трогались — менялись только ссылки/промо на главной.

## Проверки
- `tsc --noEmit` — чисто
- `npm run build` — проходит
- Тесты главной (промо ниже hero, ссылка в шапке) снова зелёные; полный набор — 8 предсуществующих падений, не связанных с правкой (нет `php`, дрейф KB #14/#16, theme)
- Визуальная проверка в браузере: промо-блок и nav-ссылка отрисованы

🤖 Generated with [Claude Code](https://claude.com/claude-code)