### PR TITLE
feat(agent-platforms): добавить в сравнение 1С:Элемент и агентов-программистов (Claude Code, Codex)

### DIFF
--- a/scripts/prerender-agent-platforms.mjs
+++ b/scripts/prerender-agent-platforms.mjs
@@ -116,9 +116,24 @@ const ruPlatforms = [
   { h: 'ELMA365', p: 'Low-code экосистема BPM/CRM/КЭДО с ИИ-ассистентом, который помогает человеку в визуальном конструкторе (human-in-the-loop).' },
   { h: 'BPMSoft', p: 'Low-code BPM/CRM (замена Creatio, реестр РФ, ФСТЭК) с LLM-агентами, но агент автоматизирует бизнес-процессы, а не схему и права.' },
   { h: 'AppMaster', p: 'No-code с ИИ-генерацией исходного кода (бэкенд, веб, мобайл), но это реальный код с риском поломки и без единого админ-API.' },
+  { h: '1С:Элемент', p: 'Облачная low-code среда 1С для веб-кабинетов, порталов, браузерных и мобильных приложений, но приложение пишет разработчик — ИИ-сборки нет.' },
 ]
 
 const ruPlatformsHtml = ruPlatforms
+  .map(
+    (p) => `
+      <section class="ap-prerender__group">
+        <h3>${escape(p.h)}</h3>
+        <p>${escape(p.p)}</p>
+      </section>`
+  )
+  .join('')
+
+const codingAgents = [
+  { h: 'Claude Code, Codex и другие агенты-кодеры', p: 'Автономные агенты-программисты сами пишут реальный код в репозитории, гоняют тесты и делают PR — мощно и гибко. Но БД, миграции, права, деплой и безопасность остаются на вас, нет встроенной безопасной модели данных и единого админ-API, а не-разработчик получает код, а не готовый самоадминистрируемый сервис.' },
+]
+
+const codingAgentsHtml = codingAgents
   .map(
     (p) => `
       <section class="ap-prerender__group">
@@ -144,6 +159,8 @@ const bodyHtml = `
   ${competitorsHtml}
   <h2>Российские аналоги</h2>
   ${ruPlatformsHtml}
+  <h2>А ИИ-агенты-программисты?</h2>
+  ${codingAgentsHtml}
   <h2>Чем Интеграм уникален для полной автоматизации</h2>
   ${pillarsHtml}
   <section class="ap-prerender__group">
@@ -191,7 +208,7 @@ const canonical = `${SITE}${PATH}`
 const ogTitle =
   'Агент создаёт приложение: Интеграм против зарубежных и российских low-code платформ'
 const ogDescription =
-  'Подробное сравнение Интеграма с low-code платформами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: за рубежом — Retool AI, Power Platform Copilot, NocoDB, Appsmith; в России — Bpium, ELMA365, BPMSoft, AppMaster.'
+  'Подробное сравнение Интеграма с low-code платформами и агентами-программистами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: за рубежом — Retool AI, Power Platform Copilot, NocoDB, Appsmith; в России — Bpium, ELMA365, BPMSoft, AppMaster, 1С:Элемент; агенты-кодеры — Claude Code, Codex.'
 const ogImage = `${SITE}/og/knowledge-base.png`
 
 const jsonLd = {

--- a/src/pages/AgentPlatforms.tsx
+++ b/src/pages/AgentPlatforms.tsx
@@ -22,6 +22,7 @@ import {
   FileCode2,
   Sparkles,
   Building2,
+  Terminal,
 } from 'lucide-react'
 
 const SITE = 'https://ideav.ru'
@@ -30,7 +31,7 @@ const PATH = '/agent-platforms.html'
 const PAGE_TITLE =
   'Агент создаёт приложение: Интеграм против зарубежных и российских low-code платформ'
 const PAGE_DESCRIPTION =
-  'Подробное сравнение Интеграма с low-code платформами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: за рубежом — Retool AI, Power Platform Copilot, NocoDB, Appsmith; в России — Bpium, ELMA365, BPMSoft, AppMaster.'
+  'Подробное сравнение Интеграма с low-code платформами и агентами-программистами по модели «ИИ-агент создаёт и администрирует сервис под ключ»: за рубежом — Retool AI, Power Platform Copilot, NocoDB, Appsmith; в России — Bpium, ELMA365, BPMSoft, AppMaster, 1С:Элемент; агенты-кодеры — Claude Code, Codex.'
 
 function setMetaTag(selector: string, attr: 'name' | 'property', key: string, content: string) {
   let el = document.head.querySelector<HTMLMetaElement>(selector)
@@ -201,6 +202,12 @@ const ruPlatforms = [
     ai: 'ИИ собирает приложение и API по описанию',
     gap: 'Реальный код — риск; нет единого админ-API',
   },
+  {
+    name: '1С:Элемент',
+    what: 'Облачная low-code среда 1С: веб-кабинеты, порталы, мобайл',
+    ai: 'ИИ-сборки приложения нет — пишет разработчик',
+    gap: 'Среда для разработчика, не для не-кодера',
+  },
 ]
 
 // Полный цикл, который агент проходит без захода в интерфейс.
@@ -221,7 +228,7 @@ export default function AgentPlatforms() {
 
     setMetaTag('meta[name="description"]', 'name', 'description', PAGE_DESCRIPTION)
     setMetaTag('meta[name="keywords"]', 'name', 'keywords',
-      'ии-агент создаёт приложение,low-code,no-code,retool ai,power platform copilot,nocodb,appsmith,bpium,elma365,bpmsoft,appmaster,российские low-code платформы,интеграм,автоматизация без программиста,замена разработчика')
+      'ии-агент создаёт приложение,low-code,no-code,retool ai,power platform copilot,nocodb,appsmith,bpium,elma365,bpmsoft,appmaster,1с:элемент,claude code,codex,агент-программист,российские low-code платформы,интеграм,автоматизация без программиста,замена разработчика')
     setMetaTag('meta[property="og:type"]', 'property', 'og:type', 'article')
     setMetaTag('meta[property="og:title"]', 'property', 'og:title', PAGE_TITLE)
     setMetaTag('meta[property="og:description"]', 'property', 'og:description', PAGE_DESCRIPTION)
@@ -466,6 +473,56 @@ export default function AgentPlatforms() {
         </div>
       </section>
 
+      {/* AI coding agents */}
+      <section className="py-16 border-t border-slate-200 dark:border-slate-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-2 mb-2">
+            <Terminal size={22} className="text-blue-600 dark:text-blue-400" />
+            <h2 className="text-2xl md:text-3xl font-bold">А ИИ-агенты-программисты?</h2>
+          </div>
+          <p className="text-slate-500 dark:text-slate-400 mb-8 max-w-2xl">
+            Claude Code (Anthropic) и Codex (OpenAI) — автономные агенты, которые сами пишут реальный
+            код: читают репозиторий, правят файлы, гоняют тесты, делают коммиты и PR. Мощно и гибко —
+            но это другой класс инструмента.
+          </p>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* Coding agents */}
+            <div className="p-6 rounded-3xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950">
+              <div className="flex items-center gap-2 mb-4">
+                <Code2 size={20} className="text-amber-500" />
+                <h3 className="text-lg font-bold">Агент-программист — Claude Code, Codex</h3>
+              </div>
+              <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                <li className="flex items-start gap-2"><CheckCircle2 size={16} className="text-slate-400 shrink-0 mt-0.5" /> Пишет настоящий код в настоящем репозитории</li>
+                <li className="flex items-start gap-2"><AlertTriangle size={16} className="text-amber-500 shrink-0 mt-0.5" /> БД, миграции, права, деплой, хостинг и безопасность — на вас</li>
+                <li className="flex items-start gap-2"><AlertTriangle size={16} className="text-amber-500 shrink-0 mt-0.5" /> Нет встроенной безопасной модели данных и единого админ-API</li>
+                <li className="flex items-start gap-2"><AlertTriangle size={16} className="text-amber-500 shrink-0 mt-0.5" /> Не-разработчик получает код, а не готовый сервис</li>
+              </ul>
+            </div>
+
+            {/* Integram */}
+            <div className="p-6 rounded-3xl border border-blue-300 dark:border-blue-900/50 bg-gradient-to-b from-blue-50 to-white dark:from-blue-950/40 dark:to-slate-950">
+              <div className="flex items-center gap-2 mb-4">
+                <Bot size={20} className="text-blue-500" />
+                <h3 className="text-lg font-bold">Интеграм</h3>
+              </div>
+              <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                <li className="flex items-start gap-2"><CheckCircle2 size={16} className="text-blue-500 shrink-0 mt-0.5" /> Агент собирает на управляемой платформе, а не в сыром коде</li>
+                <li className="flex items-start gap-2"><CheckCircle2 size={16} className="text-blue-500 shrink-0 mt-0.5" /> Единый безопасный API: схема, данные, роли, шаблоны</li>
+                <li className="flex items-start gap-2"><CheckCircle2 size={16} className="text-blue-500 shrink-0 mt-0.5" /> Роли, права и хостинг в РФ — из коробки</li>
+                <li className="flex items-start gap-2"><CheckCircle2 size={16} className="text-blue-500 shrink-0 mt-0.5" /> Не-разработчик получает работающий сервис, который агент админит</li>
+              </ul>
+            </div>
+          </div>
+
+          <p className="text-xs text-slate-400 dark:text-slate-500 mt-3">
+            То же касается Cursor, GitHub Copilot и других агентов-кодеров: это инструменты разработчика,
+            а не платформа, отдающая бизнесу готовый самоадминистрируемый сервис.
+          </p>
+        </div>
+      </section>
+
       {/* Three pillars */}
       <section className="py-16 border-t border-slate-200 dark:border-slate-900 bg-slate-50/60 dark:bg-slate-900/30">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -499,8 +556,13 @@ export default function AgentPlatforms() {
           <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed mb-4">
             Ни за рубежом, ни в России нет точного аналога Интеграма по уровню контроля агента над
             платформой. Зарубежные (Retool, Power Platform, NocoDB, Appsmith) и российские (Bpium,
-            ELMA365, BPMSoft, AppMaster) решения заточены на human-in-the-loop: человек кликает в
-            интерфейсе, агент помогает.
+            ELMA365, BPMSoft, AppMaster, 1С:Элемент) решения заточены на human-in-the-loop: человек
+            кликает в интерфейсе, агент помогает.
+          </p>
+          <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed mb-4">
+            Универсальные агенты-программисты (Claude Code, Codex) умеют больше — но отдают исходный
+            код, который вам нужно хостить, администрировать и защищать; готового самоадминистрируемого
+            сервиса не-разработчик не получает.
           </p>
           <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed mb-10">
             Интеграм — платформа, где агент проходит полный цикл: структура базы → наполнение → роли и

--- a/tests/issue-360-agent-platforms.test.mjs
+++ b/tests/issue-360-agent-platforms.test.mjs
@@ -55,6 +55,13 @@ test('the detailed page covers Russian low-code analogs', () => {
   assert.match(pageSource, /ELMA365/)
   assert.match(pageSource, /BPMSoft/)
   assert.match(pageSource, /AppMaster/)
+  assert.match(pageSource, /1С:Элемент/)
+})
+
+test('the detailed page covers AI coding agents (Claude Code, Codex)', () => {
+  assert.match(pageSource, /ИИ-агенты-программисты/)
+  assert.match(pageSource, /Claude Code/)
+  assert.match(pageSource, /Codex/)
 })
 
 test('the detailed page sets its own SEO title, description and canonical', () => {
@@ -114,6 +121,11 @@ test('prerender-agent-platforms writes a crawlable dist/agent-platforms.html', (
   assert.match(out, /Российские аналоги/)
   assert.match(out, /Bpium/)
   assert.match(out, /BPMSoft/)
+  assert.match(out, /1С:Элемент/)
+
+  // AI coding agents section is crawlable too.
+  assert.match(out, /Claude Code/)
+  assert.match(out, /Codex/)
 
   // SEO head tags: canonical, Open Graph, Article JSON-LD, tightened title.
   assert.match(out, /<link rel="canonical" href="https:\/\/ideav\.ru\/agent-platforms\.html" \/>/)


### PR DESCRIPTION
Расширяет сравнение на странице `/agent-platforms.html` (вслед за #361).

## Что добавлено
- **1С:Элемент** — 5-я строка таблицы «Российские аналоги»: облачная low-code среда 1С (веб-кабинеты, порталы, мобайл); приложение пишет разработчик — ИИ-сборки нет.
- **Блок «А ИИ-агенты-программисты?»** — отдельный класс инструментов: **Claude Code** (Anthropic) и **Codex** (OpenAI). Две карточки с честным контрастом: агенты пишут реальный код в репозитории (мощно и гибко), но БД, миграции, права, деплой, хостинг и безопасность — на пользователе, нет встроенной безопасной модели данных и единого админ-API, не-разработчик получает код, а не готовый самоадминистрируемый сервис. Примечание про Cursor / GitHub Copilot.
- Обновлены «Вывод», SEO (title/description/keywords), prerender-снимок (новые блоки попадают в crawlable-HTML) и тесты.

## Факты (проверено по открытым источникам)
- 1С:Элемент (1С:Предприятие.Элемент) — облачная low-code среда разработки 1С.
- Codex (OpenAI) — в 2025–2026 облачный автономный агент-инженер (пишет фичи, чинит баги, делает PR).
- Claude Code (Anthropic) — терминальный агентный инструмент: правит файлы, гоняет тесты, ведёт git.

## Проверки
- `tsc --noEmit` — чисто
- `npm run build` — проходит; `1С:Элемент`, `Claude Code`, `Codex`, заголовок блока есть в `dist/agent-platforms.html`
- Тесты 11/11 (добавлены проверки 1С:Элемент и агентов-кодеров)
- Визуальная проверка в браузере (светлая тема): новый блок и 5-я строка таблицы

🤖 Generated with [Claude Code](https://claude.com/claude-code)