### PR TITLE
Переделать H1 на agent-platforms.html

### DIFF
--- a/scripts/prerender-agent-platforms.mjs
+++ b/scripts/prerender-agent-platforms.mjs
@@ -147,7 +147,7 @@ const bodyHtml = `
 <article id="ap-prerender" itemscope itemtype="https://schema.org/Article">
   <header>
     <p class="ap-prerender__eyebrow">Агент как полноценный разработчик</p>
-    <h1 itemprop="headline">Сервис целиком создаёт и администрирует агент — кто это уже умеет</h1>
+    <h1 itemprop="headline">ИИ-агент собирает и ведёт приложение под ключ</h1>
     <p class="ap-prerender__lead" itemprop="description">
       Подход «приложение полностью собирается ИИ-агентом» — горячий фронт. Ниже честное сравнение
       Интеграма с лучшими решениями за рубежом (Retool AI, Power Platform Copilot, NocoDB, Appsmith)

--- a/src/pages/AgentPlatforms.tsx
+++ b/src/pages/AgentPlatforms.tsx
@@ -266,8 +266,8 @@ export default function AgentPlatforms() {
             transition={{ duration: 0.5 }}
             className="text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight mb-5"
           >
-            Сервис целиком создаёт и администрирует агент —{' '}
-            <span className="text-blue-500">кто это уже умеет</span>
+            ИИ-агент собирает и ведёт приложение{' '}
+            <span className="text-blue-500">под ключ</span>
           </motion.h1>
 
           <p className="text-lg text-slate-600 dark:text-slate-300 leading-relaxed">


### PR DESCRIPTION
Closes #366

## Проблема
H1 на `agent-platforms.html` — **«Сервис целиком создаёт и администрирует агент — кто это уже умеет»**: длинный и читался неоднозначно (вопрос это или утверждение).

## Решение
Короткий декларативный заголовок:

> **ИИ-агент собирает и ведёт приложение _под ключ_**

(акцентная часть «под ключ» — синим, как и было по дизайну). Поправлено **синхронно** в двух местах:
- `src/pages/AgentPlatforms.tsx` — видимый H1 (React)
- `scripts/prerender-agent-platforms.mjs` — тот же H1 в prerendered-fallback (для краулеров/без JS)

`PAGE_TITLE` / og-title / `<title>` **не меняются** — они и так корректные («Агент создаёт приложение: Интеграм против зарубежных и российских low-code платформ»).

## Проверка
- ✅ `npm run build` проходит; `dist/agent-platforms.html` содержит новый H1, старой строки в `dist/` нет
- ✅ Новый текст присутствует и в React-бандле, и в prerendered HTML
- ✅ `<title>`/og не затронуты
- ✅ `node --test tests/issue-360-agent-platforms.test.mjs` — 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)