### PR TITLE
feat(header): пункт меню «Ещё» с выпадающим списком (#381)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,22 +1,33 @@
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { Menu, X, Sun, Moon } from 'lucide-react'
+import { Menu, X, Sun, Moon, ChevronDown } from 'lucide-react'
 import { useState } from 'react'
 import { useTheme } from '../context/ThemeContext'
 import { Logo } from './Logo'
 
 export function Header() {
   const [isOpen, setIsOpen] = useState(false)
+  const [moreOpen, setMoreOpen] = useState(false)
   const { theme, toggleTheme } = useTheme()
 
   const navLinks = [
-    { name: 'Excel → приложение', href: '/excel-to-app.html' },
     { name: 'Технология', href: '/#technology' },
     { name: 'Как работаем', href: '/#process' },
     { name: 'Примеры', href: '/#cases' },
     { name: 'Цены', href: '/#pricing' },
     { name: 'База знаний', href: '/knowledge-base.html' },
     { name: 'Блог', href: 'https://blog.ideav.ru/', external: true },
+  ]
+
+  // «Ещё...» — раскрывающийся список: сюда складываем новое и интересное
+  const moreLinks = [
+    { name: 'Excel → приложение', href: '/excel-to-app.html' },
+    { name: 'Сопоставление каталогов', href: '/catalog-matching.html' },
+    {
+      name: 'Предпосылки no-code конструктора',
+      href: 'https://blog.ideav.ru/posts/predposylki-no-code-konstruktora-integram/',
+      external: true,
+    },
   ]
 
   return (
@@ -41,6 +52,36 @@ export function Header() {
                 {link.name}
               </a>
             ))}
+
+            {/* «Ещё...» dropdown */}
+            <div className="relative group">
+              <button
+                type="button"
+                aria-haspopup="true"
+                className="flex items-center gap-1 text-sm font-medium text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 group-focus-within:text-blue-500 dark:group-focus-within:text-blue-400 transition-colors"
+              >
+                Ещё
+                <ChevronDown
+                  size={14}
+                  className="transition-transform group-hover:rotate-180 group-focus-within:rotate-180"
+                />
+              </button>
+              <div className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 absolute right-0 top-full pt-3 transition-all duration-150">
+                <div className="w-64 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-xl shadow-slate-900/5 p-2">
+                  {moreLinks.map((link) => (
+                    <a
+                      key={link.name}
+                      href={link.href}
+                      {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                      className="block px-3 py-2.5 rounded-lg text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-blue-500 dark:hover:text-blue-400 hover:bg-slate-50 dark:hover:bg-slate-800/60 transition-colors"
+                    >
+                      {link.name}
+                    </a>
+                  ))}
+                </div>
+              </div>
+            </div>
+
             <button
               onClick={toggleTheme}
               aria-label={theme === 'dark' ? 'Включить светлую тему' : 'Включить тёмную тему'}
@@ -96,6 +137,38 @@ export function Header() {
                 {link.name}
               </a>
             ))}
+
+            {/* «Ещё...» — раскрывающийся раздел */}
+            <div className="border-b border-slate-100 dark:border-slate-800/50">
+              <button
+                type="button"
+                onClick={() => setMoreOpen((v) => !v)}
+                aria-expanded={moreOpen}
+                className="flex items-center justify-between w-full px-3 py-4 text-base font-medium text-slate-600 dark:text-slate-300 hover:text-blue-500 dark:hover:text-blue-400"
+              >
+                Ещё
+                <ChevronDown
+                  size={18}
+                  className={`transition-transform ${moreOpen ? 'rotate-180' : ''}`}
+                />
+              </button>
+              {moreOpen && (
+                <div className="pb-2">
+                  {moreLinks.map((link) => (
+                    <a
+                      key={link.name}
+                      href={link.href}
+                      onClick={() => setIsOpen(false)}
+                      {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                      className="block pl-6 pr-3 py-3 text-base text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400"
+                    >
+                      {link.name}
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+
             <div className="pt-4 px-3">
               <a
                 href="https://ideav.ru/start.html"


### PR DESCRIPTION
Closes #381.

Убрал «Excel → приложение» из основного меню в шапке и добавил в его конец раскрывающийся пункт **«Ещё»** — сюда складываем новое и интересное.

## Что внутри «Ещё»
- **Excel → приложение** → `/excel-to-app.html`
- **Сопоставление каталогов** → `/catalog-matching.html` (страница из #379)
- **Предпосылки no-code конструктора** → [статья в блоге](https://blog.ideav.ru/posts/predposylki-no-code-konstruktora-integram/)

## Поведение
- **Десктоп:** dropdown открывается по наведению и по фокусу с клавиатуры (`group-hover` / `group-focus-within`), стрелка-шеврон поворачивается.
- **Мобильный:** «Ещё» раскрывается по тапу (отдельное состояние), ссылки закрывают меню по клику.
- Внешняя ссылка открывается в новой вкладке с `rel="noopener noreferrer"`.

## Проверка
- `tsc --noEmit` — без ошибок, `vite build` собирается.
- Визуально через Playwright: пункт Excel из основного меню исчез, «Ещё» в конце, dropdown содержит ровно три ссылки с корректными URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
