### PR TITLE
fix(catalog-matching): разделить «К базе знаний» и бейдж (#385)

### DIFF
--- a/src/pages/CatalogMatching.tsx
+++ b/src/pages/CatalogMatching.tsx
@@ -187,7 +187,7 @@ export default function CatalogMatching() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <Link
             to="/knowledge-base.html"
-            className="inline-flex items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
+            className="flex w-fit items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
           >
             <ArrowLeft size={16} /> К базе знаний
           </Link>


### PR DESCRIPTION
Closes #385.

В шапке страницы `catalog-matching.html` ссылка **«← К базе знаний»** и бейдж **«Инструмент на конструкторе Интеграм»** слипались в одну строку — оба были `inline-flex`.

## Фикс
Ссылку «К базе знаний» сделал блочной (`inline-flex` → `flex w-fit`): теперь она занимает свою строку, а уже имевшийся отступ `mb-6` отделяет её от бейджа снизу. Бейдж — на отдельной строке под ссылкой.

`w-fit` оставляет кликабельную область по ширине содержимого (ссылка не растягивается на всю строку).

## Проверка
Визуально через Playwright (`/catalog-matching`): ссылка и бейдж теперь на разных строках, разделены — как в макете.

> Примечание: тот же приём (две `inline-flex`-плашки подряд) есть на `agent-platforms.html` — там визуально та же слипшаяся пара. В рамках этой задачи не трогал; при желании поправлю отдельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
