### PR TITLE
feat(catalog-matching): прикрепление двух каталогов с заливкой в GitHub (#389)

### DIFF
--- a/public/excel-to-app.php
+++ b/public/excel-to-app.php
@@ -54,6 +54,16 @@ $contact = trim((string) ($_POST['contact'] ?? ''));
 // The landing labels this field "тематика"; accept a couple of aliases.
 $topic   = trim((string) ($_POST['topic'] ?? $_POST['task'] ?? $_POST['theme'] ?? ''));
 
+// Which landing form the request came from. Drives the issue/notification
+// wording so a "сопоставление каталогов" заявка doesn't read as "Excel → app".
+// Same source vocabulary as telegram-notify.php; defaults to the original form.
+$source = trim((string) ($_POST['source'] ?? 'excel-to-app'));
+$SOURCE_LABELS = [
+    'catalog-matching' => 'Сопоставление каталогов',
+    'excel-to-app'     => 'Excel → приложение',
+];
+$sourceLabel = $SOURCE_LABELS[$source] ?? ($source !== '' ? $source : 'Excel → приложение');
+
 // ── Spam protection: SmartCaptcha (skipped for known logged-in users) ─────────
 $hasIdbCookie = intake_has_idb_cookie($_COOKIE);
 $captchaToken = trim((string) ($_POST['captcha_token'] ?? ''));
@@ -147,8 +157,8 @@ foreach ($uploads as $index => $file) {
 }
 
 // ── Create the issue ──────────────────────────────────────────────────────────
-$issueTitle = 'Заявка Excel→приложение' . ($company !== '' ? ": $company" : ($name !== '' ? ": $name" : ''));
-$issueBody  = intake_build_issue_body($name, $company, $contact, $topic, $attachmentLinks, $requestId);
+$issueTitle = "Заявка: $sourceLabel" . ($company !== '' ? " — $company" : ($name !== '' ? " — $name" : ''));
+$issueBody  = intake_build_issue_body($sourceLabel, $name, $company, $contact, $topic, $attachmentLinks, $requestId);
 
 $issueResult = intake_github_create_issue($issueRepo, $issueTitle, $issueBody, $labels, $githubToken, $apiBase);
 if (!$issueResult['ok']) {
@@ -167,7 +177,7 @@ $botToken = (string) intake_config('TELEGRAM_BOT_TOKEN', '');
 $chatId   = (string) intake_config('TELEGRAM_CHAT_ID', '');
 if ($botToken !== '' && $chatId !== '') {
     $tgBase  = (string) intake_config('TELEGRAM_API_BASE', 'https://api.telegram.org');
-    $message = intake_build_telegram_message($name, $company, $contact, $topic, $attachmentLinks, $issueUrl);
+    $message = intake_build_telegram_message($sourceLabel, $name, $company, $contact, $topic, $attachmentLinks, $issueUrl);
     $tg = intake_telegram_send_message($botToken, $chatId, $message, $tgBase);
     $telegramSent = $tg['ok'];
 }
@@ -225,8 +235,8 @@ function intake_collect_uploads(array $files): array {
 }
 
 /** Compose the GitHub issue body (Markdown). */
-function intake_build_issue_body(string $name, string $company, string $contact, string $topic, array $attachments, string $requestId): string {
-    $lines = ['## Новая заявка «Excel → приложение»', ''];
+function intake_build_issue_body(string $heading, string $name, string $company, string $contact, string $topic, array $attachments, string $requestId): string {
+    $lines = ["## Новая заявка «$heading»", ''];
     if ($name !== '')    $lines[] = "- **Имя:** $name";
     if ($company !== '') $lines[] = "- **Компания:** $company";
     if ($contact !== '') $lines[] = "- **Контакт:** $contact";
@@ -252,9 +262,9 @@ function intake_build_issue_body(string $name, string $company, string $contact,
 }
 
 /** Compose the Telegram notification (MarkdownV2). */
-function intake_build_telegram_message(string $name, string $company, string $contact, string $topic, array $attachments, string $issueUrl): string {
+function intake_build_telegram_message(string $heading, string $name, string $company, string $contact, string $topic, array $attachments, string $issueUrl): string {
     $e = 'intake_escape_markdown';
-    $lines = ['*Новая заявка «Excel → приложение»*'];
+    $lines = ['*Новая заявка «' . $heading . '»*'];
     if ($name !== '')    $lines[] = '👤 *Имя:* ' . $e($name);
     if ($company !== '') $lines[] = '🏢 *Компания:* ' . $e($company);
     if ($contact !== '') $lines[] = '📬 *Контакт:* ' . $e($contact);

--- a/src/pages/CatalogMatching.tsx
+++ b/src/pages/CatalogMatching.tsx
@@ -20,6 +20,8 @@ import {
   ListChecks,
   Play,
   Send,
+  Paperclip,
+  Trash2,
 } from 'lucide-react'
 
 declare global {
@@ -41,12 +43,31 @@ declare global {
 type FormState = 'idle' | 'sending' | 'success' | 'error'
 
 const CAPTCHA_CLIENT_KEY = (import.meta.env.VITE_SMARTCAPTCHA_CLIENT_KEY as string | undefined) ?? ''
-// Тот же бэкенд-обработчик, что и у формы на главной: проверяет same-host + капчу
-// и отправляет заявку в Telegram. Поле source отличает заявку с этой страницы.
-const SUBMIT_ENDPOINT = '/telegram-notify.php'
+// Общий обработчик приёма заявок (A2): принимает multipart-форму, коммитит
+// вложения в каталог orders/ репозитория на GitHub, заводит issue со ссылками
+// на файлы и шлёт уведомление в Telegram. Поле source = 'catalog-matching'
+// отличает заявку с этой страницы (см. public/excel-to-app.php).
+const SUBMIT_ENDPOINT = '/excel-to-app.php'
+
+// Два каталога — необязательные вложения (#389): свой каталог (SKU) и каталог
+// контрагента (RFP). Те же форматы и лимиты, что и на /excel-to-app.html.
+const ACCEPTED_EXTENSIONS = ['.xlsx', '.xls', '.csv', '.ods']
+const ACCEPT_ATTR = ACCEPTED_EXTENSIONS.join(',')
+const MAX_FILE_BYTES = 25 * 1024 * 1024
 
 function hasIdbCookie(): boolean {
   return document.cookie.split(';').some((c) => c.trimStart().startsWith('idb_'))
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} Б`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} КБ`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} МБ`
+}
+
+function hasAcceptedExtension(name: string): boolean {
+  const lower = name.toLowerCase()
+  return ACCEPTED_EXTENSIONS.some((ext) => lower.endsWith(ext))
 }
 
 const SITE = 'https://ideav.ru'
@@ -185,6 +206,69 @@ const pillars = [
   },
 ]
 
+// Один необязательный файл-каталог: пустое состояние — кликабельная зона
+// «Прикрепить файл», заполненное — имя файла, размер и кнопка «убрать».
+function CatalogFileInput({
+  id,
+  label,
+  hint,
+  file,
+  onPick,
+  onClear,
+}: {
+  id: string
+  label: string
+  hint: string
+  file: File | null
+  onPick: (file: File | undefined) => void
+  onClear: () => void
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="block text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2 ml-1"
+      >
+        {label}
+      </label>
+      {file ? (
+        <div className="flex items-center gap-3 px-3 py-2.5 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950">
+          <FileSpreadsheet size={18} className="text-green-600 dark:text-green-400 shrink-0" />
+          <span className="flex-1 truncate text-sm text-slate-700 dark:text-slate-200">{file.name}</span>
+          <span className="text-xs text-slate-400 dark:text-slate-500 shrink-0">{formatBytes(file.size)}</span>
+          <button
+            type="button"
+            onClick={onClear}
+            aria-label={`Убрать файл ${file.name}`}
+            className="text-slate-400 hover:text-red-500 transition-colors shrink-0"
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+      ) : (
+        <label
+          htmlFor={id}
+          className="flex items-center gap-2 px-4 py-2.5 rounded-xl border border-dashed border-slate-300 dark:border-slate-700 hover:border-blue-400 dark:hover:border-blue-600 bg-white dark:bg-slate-950 cursor-pointer transition-colors"
+        >
+          <Paperclip size={16} className="text-blue-500 shrink-0" />
+          <span className="text-sm text-slate-600 dark:text-slate-300">Прикрепить файл</span>
+          <span className="ml-auto text-xs text-slate-400 dark:text-slate-500">{hint}</span>
+        </label>
+      )}
+      <input
+        id={id}
+        type="file"
+        accept={ACCEPT_ATTR}
+        className="sr-only"
+        onChange={(e) => {
+          onPick(e.target.files?.[0])
+          e.target.value = ''
+        }}
+      />
+    </div>
+  )
+}
+
 export default function CatalogMatching() {
   useEffect(() => {
     document.title = PAGE_TITLE
@@ -214,6 +298,8 @@ export default function CatalogMatching() {
   const [consentChecked, setConsentChecked] = useState(false)
   const [captchaToken, setCaptchaToken] = useState('')
   const [isCaptchaRequested, setIsCaptchaRequested] = useState(false)
+  const [ourCatalog, setOurCatalog] = useState<File | null>(null)
+  const [theirCatalog, setTheirCatalog] = useState<File | null>(null)
   const [idbCookieFound] = useState(() => hasIdbCookie())
   const captchaContainerRef = useRef<HTMLDivElement>(null)
   const captchaWidgetIdRef = useRef<number | null>(null)
@@ -250,39 +336,76 @@ export default function CatalogMatching() {
     }
   }, [isCaptchaRequested, idbCookieFound])
 
+  // Проверка и приём одного прикреплённого каталога (оба поля необязательные).
+  function pickCatalogFile(file: File | undefined, setFile: (f: File | null) => void) {
+    if (!file) return
+    setIsCaptchaRequested(true)
+    if (!hasAcceptedExtension(file.name)) {
+      setErrorMsg(`Поддерживаются только таблицы: ${ACCEPTED_EXTENSIONS.join(', ')}.`)
+      setFormState('error')
+      return
+    }
+    if (file.size > MAX_FILE_BYTES) {
+      setErrorMsg(`Файл должен быть не больше ${formatBytes(MAX_FILE_BYTES)}.`)
+      setFormState('error')
+      return
+    }
+    if (formState === 'error') {
+      setFormState('idle')
+      setErrorMsg('')
+    }
+    setFile(file)
+  }
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const form = e.currentTarget
-    const data: Record<string, string> = {
-      source:  'catalog-matching',
-      name:    (form.elements.namedItem('name')    as HTMLInputElement).value,
-      company: (form.elements.namedItem('company') as HTMLInputElement).value,
-      contact: (form.elements.namedItem('contact') as HTMLInputElement).value,
-      task:    (form.elements.namedItem('task')    as HTMLTextAreaElement).value,
+    const name    = (form.elements.namedItem('name')    as HTMLInputElement).value.trim()
+    const company = (form.elements.namedItem('company') as HTMLInputElement).value.trim()
+    const contact = (form.elements.namedItem('contact') as HTMLInputElement).value.trim()
+    const task    = (form.elements.namedItem('task')    as HTMLTextAreaElement).value.trim()
+
+    if (!contact) {
+      setErrorMsg('Укажите контакт — email или Telegram, куда прислать результат.')
+      setFormState('error')
+      return
     }
 
-    if (CAPTCHA_CLIENT_KEY && !idbCookieFound) {
-      if (!captchaToken) {
-        setErrorMsg('Пожалуйста, пройдите проверку капчи.')
-        setFormState('error')
-        return
-      }
-      data.captcha_token = captchaToken
+    const captchaActive = Boolean(CAPTCHA_CLIENT_KEY) && !idbCookieFound
+    if (captchaActive && !captchaToken) {
+      setErrorMsg('Пожалуйста, пройдите проверку капчи.')
+      setFormState('error')
+      return
     }
 
     setFormState('sending')
     setErrorMsg('')
 
+    const payload = new FormData()
+    payload.append('source', 'catalog-matching')
+    payload.append('name', name)
+    payload.append('company', company)
+    payload.append('contact', contact)
+    payload.append('task', task)
+    if (captchaActive) {
+      payload.append('captcha_token', captchaToken)
+    }
+    // Имя файла кодирует роль каталога, чтобы её было видно в orders/ и в issue:
+    // SKU — наш каталог, RFP — каталог контрагента. Оба вложения необязательны.
+    if (ourCatalog)   payload.append('files[]', ourCatalog,   `SKU-${ourCatalog.name}`)
+    if (theirCatalog) payload.append('files[]', theirCatalog, `RFP-${theirCatalog.name}`)
+
     try {
       const res = await fetch(SUBMIT_ENDPOINT, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
+        body: payload,
       })
-      const json = await res.json()
-      if (json.ok) {
+      const json = await res.json().catch(() => ({ ok: false }))
+      if (res.ok && json.ok) {
         setFormState('success')
         form.reset()
+        setOurCatalog(null)
+        setTheirCatalog(null)
         setConsentChecked(false)
         setCaptchaToken('')
         setIsCaptchaRequested(false)
@@ -600,6 +723,37 @@ export default function CatalogMatching() {
                   rows={3}
                   className="w-full bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-2.5 text-slate-800 dark:text-slate-100 focus:border-blue-500 outline-none transition-all resize-none"
                   placeholder="Сколько позиций в каждом каталоге, в каком формате (Excel/CSV), какая номенклатура..."
+                />
+              </div>
+
+              {/* Необязательные вложения: два каталога (#389) */}
+              <div className="space-y-3 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50/60 dark:bg-slate-900/30 p-4">
+                <div className="flex items-center gap-2">
+                  <Paperclip size={14} className="text-blue-600 dark:text-blue-400" />
+                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                    Каталоги{' '}
+                    <span className="font-normal text-slate-400 dark:text-slate-500">— необязательно</span>
+                  </span>
+                </div>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Можно сразу приложить оба файла — посмотрим объём и формат заранее.{' '}
+                  {ACCEPTED_EXTENSIONS.join(', ')} · до {formatBytes(MAX_FILE_BYTES)} каждый.
+                </p>
+                <CatalogFileInput
+                  id="cm-our-catalog"
+                  label="Ваш каталог (SKU)"
+                  hint="ваши артикулы"
+                  file={ourCatalog}
+                  onPick={(f) => pickCatalogFile(f, setOurCatalog)}
+                  onClear={() => setOurCatalog(null)}
+                />
+                <CatalogFileInput
+                  id="cm-their-catalog"
+                  label="Каталог контрагента (RFP)"
+                  hint="куда ищем соответствия"
+                  file={theirCatalog}
+                  onPick={(f) => pickCatalogFile(f, setTheirCatalog)}
+                  onClear={() => setTheirCatalog(null)}
                 />
               </div>
 

--- a/tests/excel-to-app-backend.test.mjs
+++ b/tests/excel-to-app-backend.test.mjs
@@ -139,6 +139,73 @@ test('end-to-end: form upload creates issue, attaches file, notifies Telegram', 
   }
 })
 
+test('end-to-end: catalog-matching source uses its own wording and accepts two files', async () => {
+  // Issue #389: the catalog-matching form reuses this A2 handler but must read
+  // as «Сопоставление каталогов», not «Excel → приложение», and accept the two
+  // optional catalogs (our SKU + the counterparty's RFP).
+  const mockPort = await getFreePort()
+  const appPort = await getFreePort()
+  const workdir = mkdtempSync(join(tmpdir(), 'catalog-matching-e2e-'))
+  const mockLog = join(workdir, 'mock.log')
+
+  const mockProc = spawn('php', ['-S', `127.0.0.1:${mockPort}`, join(root, 'tests/fixtures/intake-mock-api.php')], {
+    env: { ...process.env, MOCK_LOG: mockLog },
+    stdio: 'ignore',
+  })
+
+  const appProc = spawn('php', ['-S', `127.0.0.1:${appPort}`, '-t', join(root, 'public')], {
+    env: {
+      ...process.env,
+      INTAKE_SKIP_HOST_CHECK: '1',
+      SMARTCAPTCHA_SERVER_KEY: '',
+      GITHUB_TOKEN: 'test-token',
+      GITHUB_ISSUE_REPO: 'mock/repo',
+      GITHUB_UPLOAD_REPO: 'mock/repo',
+      GITHUB_API_BASE: `http://127.0.0.1:${mockPort}`,
+      TELEGRAM_BOT_TOKEN: 'bot:test',
+      TELEGRAM_CHAT_ID: '123',
+      TELEGRAM_API_BASE: `http://127.0.0.1:${mockPort}`,
+      INTAKE_RATE_LIMIT_DIR: join(workdir, 'rl'),
+    },
+    stdio: 'ignore',
+  })
+
+  try {
+    await waitForPort(mockPort)
+    await waitForPort(appPort)
+
+    const form = new FormData()
+    form.set('source', 'catalog-matching')
+    form.set('contact', 'buyer@example.com')
+    form.set('task', 'Подобрать наши аналоги к 22 000 позиций контрагента')
+    form.append('files[]', new Blob(['a;b\n1;2\n'], { type: 'text/csv' }), 'SKU-our.csv')
+    form.append('files[]', new Blob(['c;d\n3;4\n'], { type: 'text/csv' }), 'RFP-their.csv')
+
+    const res = await fetch(`http://127.0.0.1:${appPort}/excel-to-app.php`, { method: 'POST', body: form })
+    const json = await res.json()
+
+    assert.equal(res.status, 200, `expected 200, got ${res.status}: ${JSON.stringify(json)}`)
+    assert.equal(json.ok, true, JSON.stringify(json))
+    assert.equal(json.attachments, 2, 'both catalogs should be uploaded')
+
+    const log = existsSync(mockLog) ? readFileSync(mockLog, 'utf8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l)) : []
+    const puts = log.filter(e => e.method === 'PUT' && e.path.includes('/contents/'))
+    const postIssue = log.find(e => e.method === 'POST' && e.path.endsWith('/issues'))
+
+    assert.equal(puts.length, 2, 'both catalogs should be committed via the Contents API')
+    assert.ok(puts.every(p => /orders\//.test(p.path)), 'attachments should land under orders/')
+    assert.ok(postIssue, 'an issue should be created')
+    // The issue payload JSON escapes Cyrillic as \uXXXX — decode before matching.
+    const issuePayload = JSON.parse(postIssue.body)
+    assert.match(`${issuePayload.title}\n${issuePayload.body}`, /Сопоставление каталогов/, 'issue should use the catalog-matching wording')
+    assert.doesNotMatch(`${issuePayload.title}\n${issuePayload.body}`, /Excel → приложение/, 'issue should not read as an Excel→app order')
+  } finally {
+    mockProc.kill()
+    appProc.kill()
+    rmSync(workdir, { recursive: true, force: true })
+  }
+})
+
 test('end-to-end: missing contact is rejected with 400', async () => {
   const appPort = await getFreePort()
   const appProc = spawn('php', ['-S', `127.0.0.1:${appPort}`, '-t', join(root, 'public')], {

--- a/tests/issue-389-catalog-matching-uploads.test.mjs
+++ b/tests/issue-389-catalog-matching-uploads.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+// Issue #389: the catalog-matching landing gains two OPTIONAL file fields
+// (our catalog / SKU + the counterparty's / RFP). Files are committed to the
+// GitHub orders/ folder by the shared A2 intake handler, exactly like the
+// Excel → app landing does. These assertions are PHP-free so they run locally;
+// the end-to-end PHP wiring is covered in tests/excel-to-app-backend.test.mjs.
+
+const read = (p) => readFileSync(new URL(p, import.meta.url), 'utf8')
+
+const pageSource = read('../src/pages/CatalogMatching.tsx')
+const backendSource = read('../public/excel-to-app.php')
+
+test('the catalog-matching form posts to the A2 intake handler as multipart', () => {
+  // No longer the JSON-only telegram-notify endpoint.
+  assert.doesNotMatch(pageSource, /telegram-notify\.php/)
+  assert.match(pageSource, /const SUBMIT_ENDPOINT = '\/excel-to-app\.php'/)
+  assert.match(pageSource, /new FormData\(\)/)
+  assert.match(pageSource, /payload\.append\('source', 'catalog-matching'\)/)
+  assert.match(pageSource, /fetch\(SUBMIT_ENDPOINT, \{/)
+})
+
+test('the form offers two optional catalog attachments (SKU + RFP)', () => {
+  assert.match(pageSource, /Ваш каталог \(SKU\)/)
+  assert.match(pageSource, /Каталог контрагента \(RFP\)/)
+  // Wording makes clear the attachments are not required.
+  assert.match(pageSource, /необязательно/)
+  // Two single-file pickers, kept in state.
+  assert.match(pageSource, /const \[ourCatalog, setOurCatalog\] = useState<File \| null>\(null\)/)
+  assert.match(pageSource, /const \[theirCatalog, setTheirCatalog\] = useState<File \| null>\(null\)/)
+  // Spreadsheet formats only.
+  assert.match(pageSource, /const ACCEPTED_EXTENSIONS = \[[^\]]*'\.xlsx'/)
+})
+
+test('attachments are sent under files[] with role-encoded names', () => {
+  assert.match(pageSource, /payload\.append\('files\[\]',\s+ourCatalog,\s+`SKU-\$\{ourCatalog\.name\}`\)/)
+  assert.match(pageSource, /payload\.append\('files\[\]',\s+theirCatalog,\s+`RFP-\$\{theirCatalog\.name\}`\)/)
+})
+
+test('attachments are optional but a contact is still required', () => {
+  // Files must NOT block submission (the whole point of #389).
+  assert.doesNotMatch(pageSource, /Прикрепите хотя бы один/)
+  // A contact is required so the matched pairs can be returned.
+  assert.match(pageSource, /Укажите контакт/)
+})
+
+test('the form keeps the shared SmartCaptcha flow', () => {
+  assert.match(pageSource, /if \(!CAPTCHA_CLIENT_KEY \|\| !isCaptchaRequested \|\| idbCookieFound\) return/)
+  assert.match(pageSource, /captcha_token/)
+  assert.match(pageSource, /smartcaptcha\.yandexcloud\.net\/captcha\.js/)
+})
+
+test('the A2 backend is source-aware so the wording matches the form', () => {
+  // Reads the source field and maps it to a human-readable label.
+  assert.match(backendSource, /\$_POST\['source'\]/)
+  assert.match(backendSource, /'catalog-matching'\s*=>\s*'Сопоставление каталогов'/)
+  // The label drives the issue title, issue body heading and Telegram heading.
+  assert.match(backendSource, /intake_build_issue_body\(\s*\$sourceLabel/)
+  assert.match(backendSource, /intake_build_telegram_message\(\s*\$sourceLabel/)
+})


### PR DESCRIPTION
## Что и зачем

Issue #389: форма «Сопоставить ваши каталоги» на `/catalog-matching.html` получает **два необязательных поля-вложения** — свой каталог (SKU) и каталог контрагента (RFP). Файлы заливаются в каталог `orders/` репозитория на GitHub со ссылкой в issue — так же, как это уже делает форма «Excel → приложение» (`ExcelToApp.tsx`).

Вместо дублирования всей логики (upload → issue → Telegram) переиспользован уже работающий в проде обработчик приёма заявок **A2** (`excel-to-app.php`), сделанный source-aware.

## Изменения

**`public/excel-to-app.php`** — читает поле `source` и маппит его в человекочитаемую метку (`catalog-matching → «Сопоставление каталогов»`, по умолчанию без изменений `«Excel → приложение»`). Метка определяет заголовок issue, шапку тела issue и заголовок Telegram-сообщения. Логика загрузки в `orders/`, ссылки на вложения, капча и rate-limit не тронуты.

**`src/pages/CatalogMatching.tsx`**
- Отправка переключена с JSON → `/telegram-notify.php` на multipart `FormData` → `/excel-to-app.php` с `source=catalog-matching`.
- Два одиночных файл-пикера («Ваш каталог (SKU)» / «Каталог контрагента (RFP)»), только табличные форматы, с именем/размером файла и кнопкой «убрать».
- Роль каталога кодируется в имени файла (`SKU-…` / `RFP-…`) — видно в `orders/` и в ссылках issue, даже если приложен только один файл.
- Поток SmartCaptcha сохранён 1:1; капча теперь запрашивается и при выборе файла.

**Тесты**
- `tests/issue-389-catalog-matching-uploads.test.mjs` (новый, без PHP) — проверяет endpoint/source, два необязательных поля, имена `files[]`, обязательность контакта, капчу и source-aware бэкенд.
- e2e-кейс `source=catalog-matching` в `tests/excel-to-app-backend.test.mjs` (две заливки в `orders/`, issue с правильной формулировкой).

## На что обратить внимание

1. **Контакт теперь обязателен** (клиентская проверка). Это не произвол: бэкенд A2 и так отклоняет пустой контакт с 400 — проверка на клиенте лишь убирает лишний round-trip.
2. **Каждая заявка с этой формы теперь создаёт GitHub issue** (+ Telegram), а не только Telegram-сообщение, как раньше. Это соответствует модели `ExcelToApp` и даёт трекаемую запись со ссылками на файлы. Поскольку `excel-to-app.php` уже в проде, **новой серверной конфигурации не требуется** — те же секреты (`GITHUB_TOKEN`, `GITHUB_UPLOAD_REPO=ideav/excel2app`, `TELEGRAM_*`) обслуживают обе формы.

## Проверки

- `npx tsc --noEmit` — чисто.
- Новый php-free тест — 6/6 локально. PHP-зависимые e2e (включая новый кейс) гоняются в CI, где доступен `php` (локально в песочнице `php` не установлен).
- Пререндер `/catalog-matching.html` использует собственный статический снимок и не зависит от разметки формы — не затронут.

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)