### PR TITLE
feat(blog): ссылка на следующий выпуск внизу статьи (#393)

### DIFF
--- a/blog-v2/src/pages/posts/[...slug].astro
+++ b/blog-v2/src/pages/posts/[...slug].astro
@@ -9,16 +9,28 @@ export async function getStaticPaths() {
   const ascending = [...all].sort(
     (a, b) => a.data.pubDate.valueOf() - b.data.pubDate.valueOf()
   )
-  return ascending.map((post, i) => ({
-    params: { slug: post.id },
-    props: {
-      post,
-      issueNumber: String(i + 1).padStart(3, '0'),
-    },
-  }))
+  return ascending.map((post, i) => {
+    const nextPost = ascending[i + 1]
+    return {
+      params: { slug: post.id },
+      props: {
+        post,
+        issueNumber: String(i + 1).padStart(3, '0'),
+        // Next issue in reading order (chronological), so posts can be read in
+        // sequence. Null for the latest post, which has nothing after it.
+        next: nextPost
+          ? {
+              slug: nextPost.id,
+              title: nextPost.data.title,
+              issueNumber: String(i + 2).padStart(3, '0'),
+            }
+          : null,
+      },
+    }
+  })
 }
 
-const { post, issueNumber } = Astro.props
+const { post, issueNumber, next } = Astro.props
 const { Content } = await render(post)
 
 const formattedDate = post.data.pubDate
@@ -164,18 +176,46 @@ const initial = post.data.author.charAt(0)
           <Content />
         </div>
 
-        <!-- End marker + return link -->
+        <!-- End marker -->
         <div class="mt-16 pt-8 border-t border-[var(--color-hairline-strong)]">
-          <div class="text-center mb-8">
+          <div class="text-center">
             <span class="text-[var(--color-vermilion)] text-2xl" style="font-family: var(--font-serif);">❡</span>
           </div>
-          <div class="flex items-center justify-between">
-            <a href="/" class="eyebrow link-swipe text-[var(--color-ink)]">
-              ← Все выпуски
-            </a>
-            <div class="eyebrow text-[var(--color-ink-faint)]">
-              Выпуск №&nbsp;{issueNumber}
+        </div>
+
+        <!-- Next issue — keep reading in sequence -->
+        {next && (
+          <a
+            href={`/posts/${next.slug}/`}
+            rel="next"
+            class="group block mt-10 pt-8 border-t border-[var(--color-hairline)] no-underline"
+          >
+            <div class="flex items-baseline justify-between gap-4 mb-3">
+              <span class="eyebrow text-[var(--color-ink-faint)]">Следующий выпуск</span>
+              <span class="eyebrow text-[var(--color-vermilion)]">№&nbsp;{next.issueNumber}</span>
             </div>
+            <div class="flex items-start justify-between gap-6">
+              <h2
+                class="font-[family-name:var(--font-serif)] text-2xl sm:text-[2rem] leading-[1.1] tracking-[-0.02em] text-[var(--color-ink)] transition-colors group-hover:text-[var(--color-vermilion)]"
+                style="font-variation-settings: 'opsz' 80, 'SOFT' 30; font-weight: 500;"
+              >
+                {next.title}
+              </h2>
+              <span
+                class="text-[var(--color-vermilion)] text-3xl leading-none shrink-0 transition-transform group-hover:translate-x-1"
+                aria-hidden="true"
+              >→</span>
+            </div>
+          </a>
+        )}
+
+        <!-- Return link -->
+        <div class="mt-12 pt-8 border-t border-[var(--color-hairline)] flex items-center justify-between">
+          <a href="/" class="eyebrow link-swipe text-[var(--color-ink)]">
+            ← Все выпуски
+          </a>
+          <div class="eyebrow text-[var(--color-ink-faint)]">
+            Выпуск №&nbsp;{issueNumber}
           </div>
         </div>
 

--- a/old-blog-redirect/.htaccess
+++ b/old-blog-redirect/.htaccess
@@ -36,7 +36,7 @@
   RewriteRule ^category/(o-platforme|obuchenie|pravila-predprinimatelya-v-it|proekty|razrabotka|tehnologii)/?$ https://blog.ideav.ru/category/$1/ [R=301,L,QSD]
 
   # 6. Tags present on the new blog.
-  RewriteRule ^tag/(ai|airtable|analitika|arhitektura|avtomatizaciya|bezopasnost|bitriks24|biznes|dorabotki|excel|finmodel|ii-agent|ii-chat|integracii|integram|investicii|katalogi|keisy|konstruktor|laifhaki|low-code|marketing|no-code|obuchenie|otchety|proizvodstvo|rabota-s-dannymi|razrabotka|self-hosted|sopostavlenie|spravochniki|sravnenie|ssylki|tehnologii|vozmozhnosti|yandeks-direkt|zaprosy)/?$ https://blog.ideav.ru/tag/$1/ [R=301,L,QSD]
+  RewriteRule ^tag/(ai|airtable|analitika|arhitektura|avtomatizaciya|bezopasnost|bitriks24|biznes|dorabotki|excel|finmodel|geimifikaciya|ii|ii-agent|ii-chat|integracii|integram|investicii|katalogi|keisy|konstruktor|laifhaki|low-code|marketing|no-code|obuchenie|otchety|proizvodstvo|rabota-s-dannymi|razrabotka|self-hosted|sopostavlenie|spravochniki|sravnenie|ssylki|tehnologii|vozmozhnosti|yandeks-direkt|zaprosy)/?$ https://blog.ideav.ru/tag/$1/ [R=301,L,QSD]
 
   # 7. Feeds -> new RSS.
   RewriteRule ^feed(/(rss|opml))?/?$ https://blog.ideav.ru/rss.xml [R=301,L,QSD]


### PR DESCRIPTION
## Что

Внизу каждой статьи блога (`blog-v2`) добавлен блок **«Следующий выпуск»** со ссылкой на следующую по порядку статью — чтобы читать их подряд. Решает #393.

«Следующая» = следующая в хронологическом порядке (= в порядке номеров выпусков, как они уже считаются в `getStaticPaths`/архиве). У самого свежего выпуска ссылки нет — блок просто не рендерится.

### Как выглядит

```
─────────────────────────────────────
                  ❡
─────────────────────────────────────
СЛЕДУЮЩИЙ ВЫПУСК                  № 070
ИНТЕГРАМ FC изнутри: разбираем        →
готовое приложение по экранам
─────────────────────────────────────
← ВСЕ ВЫПУСКИ              ВЫПУСК № 069
```

Оформление — в редакционном стиле страницы статьи (eyebrow, сериф-заголовок, акцент, hairline-разделители); на hover заголовок подсвечивается акцентом, стрелка сдвигается. Добавлен `rel="next"`.

## Детали

- Правка только в шаблоне `blog-v2/src/pages/posts/[...slug].astro`: в `getStaticPaths` считается `next` (следующий пост), в подвале рендерится блок.
- `astro build` зелёный (117 страниц). Проверено вживую: на 69 из 70 статей ссылка есть и ведёт на верный следующий выпуск; у №070 (самой свежей) ссылки нет.

## Попутный фикс

Второй коммit восстанавливает правило редиректа для тегов `geimifikaciya` и `ii` в `old-blog-redirect/.htaccess`. Оно было в PR #391, но при мердже в main попал только коммит со статьями — из-за чего тег «геймификация» остался без редиректа, а тест `old-blog-redirect` покраснел. Здесь main снова зелёный по этому тесту.

🤖 Generated with [Claude Code](https://claude.com/claude-code)