### PR TITLE
feat(seo): offers + WebSite.alternateName в JSON-LD лендинга (#395)

### DIFF
--- a/scripts/prerender-landing.mjs
+++ b/scripts/prerender-landing.mjs
@@ -181,6 +181,11 @@ const jsonLd = {
       '@id': `${SITE}/#website`,
       url: `${SITE}/`,
       name: PUBLISHER,
+      // alternateName зеркалит Organization: связывает имя сайта с «Integram» и
+      // «Конструктор Интеграм», помогая Google не путать домен с «Инстаграм» при
+      // автодополнении (issue #395). SearchAction не добавляем — у сайта нет
+      // URL-адресуемого поиска (?q=…), а Google требует рабочий target.
+      alternateName: ['Integram', 'Конструктор Интеграм'],
       inLanguage: 'ru',
       publisher: { '@id': `${SITE}/#organization` },
     },
@@ -216,6 +221,16 @@ const jsonLd = {
       inLanguage: 'ru',
       description:
         'Российский no-code конструктор для создания внутренних приложений, баз данных, форм и отчётов без программирования. Аналог Airtable, замена Excel и Google Sheets.',
+      // offers — бесплатный тариф «Знакомство» (см. секцию «Тарифы» выше). Закрывает
+      // non-critical замечание Google «Missing field offers» и даёт цену в rich snippet
+      // (issue #395). aggregateRating сознательно НЕ добавляем — нет реальных отзывов,
+      // фиктивный рейтинг нарушает правила Google по разметке отзывов.
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'RUB',
+        description: 'Пробный тариф «Знакомство»',
+      },
       publisher: { '@id': `${SITE}/#organization` },
     },
     {

--- a/tests/prerender-landing.test.mjs
+++ b/tests/prerender-landing.test.mjs
@@ -45,6 +45,19 @@ test('prerender-landing fills #root and injects SEO head tags into dist/index.ht
   assert.match(out, /<meta property="og:title"/)
   assert.match(out, /application\/ld\+json/)
   assert.match(out, /"@type":"SoftwareApplication"/)
+
+  // issue #395: SoftwareApplication carries a free-tier Offer, and the WebSite
+  // node mirrors Organization's alternateName for brand disambiguation. No
+  // aggregateRating (no real reviews) and no SearchAction (no search endpoint).
+  const ld = JSON.parse(
+    out.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)[1].replace(/\\u003c/g, '<'),
+  )
+  const node = (t) => ld['@graph'].find((n) => n['@type'] === t)
+  assert.deepEqual(node('WebSite').alternateName, ['Integram', 'Конструктор Интеграм'])
+  assert.equal(node('SoftwareApplication').offers.price, '0')
+  assert.equal(node('SoftwareApplication').offers.priceCurrency, 'RUB')
+  assert.ok(!('aggregateRating' in node('SoftwareApplication')), 'must not invent aggregateRating')
+  assert.ok(!JSON.stringify(ld).includes('SearchAction'), 'no SearchAction without a search endpoint')
 })
 
 test('prerender-landing is idempotent (safe to run twice)', () => {


### PR DESCRIPTION
## Контекст

Issue #395 просит добавить `FAQPage`, `offers`/`aggregateRating` и `WebSite`+`SearchAction`.

**Проверка показала, что `FAQPage` уже размечен и уже на live** (`https://ideav.ru/`, один блок `application/ld+json` с `@graph`: `WebSite · Organization · SoftwareApplication · FAQPage` + 3×Question/Answer, включая «Интеграм — это Инстаграм?»). Добавлено в #387 (`scripts/prerender-landing.mjs`). Премиса issue устарела.

> ℹ️ Почему Google Rich Results Test не показал `FAQPage`: с 2023 г. Google показывает FAQ-rich-results только для авторитетных гос/мед-сайтов. Markup при этом валиден и работает на дизамбигуацию бренда. Проверять через **validator.schema.org**, а не Rich Results Test.

## Что в этом PR

Только реально недостающее и безопасное:

- **`offers`** на `SoftwareApplication` — бесплатный тариф «Знакомство» (`price: "0"`, `RUB`). Закрывает non-critical «Missing field offers».
- **`alternateName: ["Integram","Конструктор Интеграм"]`** на `WebSite` — зеркалит `Organization`, помогает Google не путать домен с «Инстаграм» в автодополнении.

## Сознательно НЕ добавлено

- **`aggregateRating`** — нет реальных отзывов; фиктивный рейтинг нарушает [правила Google по разметке отзывов](https://developers.google.com/search/docs/appearance/structured-data/review-snippet).
- **`WebSite` `SearchAction`** — на сайте нет URL-адресуемого поиска (`?q=…`); Google требует рабочий `target`, иначе разметка невалидна. Если появится `/search?q=` — добавим отдельно.

## Тесты

`node --test tests/prerender-landing.test.mjs` — 4/4 ✅ (добавлены проверки `offers`, `WebSite.alternateName` и отсутствия `aggregateRating`/`SearchAction`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)