### PR TITLE
feat(nav): «Информационная система» в меню «Ещё» (#406)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,6 +21,7 @@ export function Header() {
 
   // «Ещё...» — раскрывающийся список: сюда складываем новое и интересное
   const moreLinks = [
+    { name: 'Информационная система', href: '/informatsionnaya-sistema.html' },
     { name: 'Excel → приложение', href: '/excel-to-app.html' },
     { name: 'Сопоставление каталогов', href: '/catalog-matching.html' },
     {

--- a/tests/issue-406-menu-information-system.test.mjs
+++ b/tests/issue-406-menu-information-system.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repo = new URL('..', import.meta.url).pathname
+const read = (p) => readFileSync(resolve(repo, p), 'utf8')
+
+const headerSource = read('src/components/Header.tsx')
+
+// Изолируем массив moreLinks («Ещё…») из исходника Header.
+function moreLinksBlock() {
+  const match = headerSource.match(/const moreLinks = \[([\s\S]*?)\n {2}\]/)
+  assert.ok(match, 'Header should declare a moreLinks array')
+  return match[1]
+}
+
+test('«Ещё» menu links to the Информационная система pillar page', () => {
+  const block = moreLinksBlock()
+  assert.match(
+    block,
+    /name:\s*'Информационная система',\s*href:\s*'\/informatsionnaya-sistema\.html'/,
+    'moreLinks should contain the Информационная система entry pointing at /informatsionnaya-sistema.html',
+  )
+})
+
+test('«Ещё» menu holds exactly 4 items', () => {
+  const block = moreLinksBlock()
+  const count = (block.match(/href:/g) || []).length
+  assert.equal(count, 4, 'the «Ещё» dropdown must always have 4 entries')
+})


### PR DESCRIPTION
Closes #406.

Пиллар-страница «Информационная система» из #405 (`ideav.ru/informatsionnaya-sistema.html`) не была доступна из навигации. Добавил её в выпадающее меню **«Ещё»** в шапке — первым пунктом. Теперь в меню ровно **4 пункта**:

1. Информационная система → `/informatsionnaya-sistema.html`
2. Excel → приложение
3. Сопоставление каталогов
4. Предпосылки no-code конструктора (внешняя)

## Что сделано
- `src/components/Header.tsx` — одна строка в массиве `moreLinks` (работает и для desktop-дропдауна, и для мобильного раскрывающегося раздела — оба рендерятся из этого же массива).
- `tests/issue-406-menu-information-system.test.mjs` — 2 проверки: наличие ссылки на пиллар и что в «Ещё» ровно 4 пункта.

## Проверка
- `npm run build` — зелёный, страница по-прежнему пререндерится (`dist/informatsionnaya-sistema.html`).
- Визуально (Playwright, `vite preview`): наведение на «Ещё» показывает 4 пункта, «Информационная система» первым; переход на `/informatsionnaya-sistema.html` открывает пиллар (title «Что такое информационная система…»).
- `node --test tests/issue-406-*.test.mjs` — 2 pass.

## Деплой
CI/CD в репозитории нет — публикует Андрей вручную: `git pull` main → `npm run build` → копирование `dist/` на хостинг ideav.ru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)