### PR TITLE
fix(seo): разлепить «На главную» и бейдж на пиллар-странице ИС (#408)

### DIFF
--- a/src/pages/InformationSystem.tsx
+++ b/src/pages/InformationSystem.tsx
@@ -306,7 +306,7 @@ export default function InformationSystem() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <Link
             to="/"
-            className="inline-flex items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
+            className="flex w-fit items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
           >
             <ArrowLeft size={16} /> На главную
           </Link>

--- a/tests/issue-408-information-system-breadcrumb.test.mjs
+++ b/tests/issue-408-information-system-breadcrumb.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repo = new URL('..', import.meta.url).pathname
+const read = (p) => readFileSync(resolve(repo, p), 'utf8')
+
+const pageSource = read('src/pages/InformationSystem.tsx')
+
+// Вырезаем блок ссылки «← На главную» из хедера пиллар-страницы.
+function backLinkClass() {
+  const match = pageSource.match(
+    /<Link\s+to="\/"\s+className="([^"]*)"[\s\S]*?На главную/,
+  )
+  assert.ok(match, 'InformationSystem should have a "На главную" back-link')
+  return match[1]
+}
+
+// Регрессия #408 / #385: ссылка «На главную» и бейдж «Основы…» слипались,
+// потому что оба были inline-flex и садились в одну строку без отступа.
+// Ссылка должна быть блочной (flex w-fit) — тогда бейдж уходит на строку ниже.
+test('«На главную» back-link is block-level so it cannot glue to the badge', () => {
+  const cls = backLinkClass()
+  assert.match(cls, /\bflex\b/, 'back-link must be a flex (block-level) element')
+  assert.match(cls, /\bw-fit\b/, 'back-link must hug its content with w-fit')
+  assert.doesNotMatch(
+    cls,
+    /\binline-flex\b/,
+    'back-link must NOT be inline-flex — that glues it to the «Основы…» badge',
+  )
+})
+
+test('the "Основы: информационные системы" badge sits in its own element', () => {
+  assert.match(
+    pageSource,
+    /<div className="[^"]*"[^>]*>\s*<BookOpen[^>]*\/>\s*Основы: информационные системы/,
+    'the category badge must render in its own block element',
+  )
+})


### PR DESCRIPTION
Closes #408.

На пиллар-странице `ideav.ru/informatsionnaya-sistema.html` (из #405) в шапке ссылка «← На главную» и бейдж «Основы: информационные системы» слипались в одну строку — «На главну**ю**Основы: информационные системы».

**Причина:** оба элемента были `inline-flex` и садились рядом на одной строке без отступа. Это ровно тот же баг, что чинили в #385 на странице сопоставления каталогов — но он вернулся на новой странице из #405 (отсюда «опять» в заголовке issue).

## Что сделано
- `src/pages/InformationSystem.tsx` — ссылка «На главную» стала блочной: `inline-flex` → `flex w-fit`. Теперь она на своей строке, а `mb-6` отделяет её от бейджа снизу (тот же приём, что в #385).
- `tests/issue-408-information-system-breadcrumb.test.mjs` — регрессионный тест: ссылка должна быть `flex w-fit` и **не** `inline-flex`, бейдж — в отдельном блоке. Чтобы баг не вернулся в третий раз.

## Проверка
- `npm run build` — зелёный.
- Визуально (Playwright, `vite preview`): «← На главную» на своей строке, бейдж «Основы: информационные системы» — строкой ниже, с отступом. Больше не слеплены.
- `npm test` — 262 pass, 10 fail (все 10 — **предсуществующие**: нет `php` в окружении + известные красные #14/#16/theme/index-seo). Мои 2 теста зелёные, регрессий ноль.

## Деплой
CI/CD в репозитории нет — публикует Андрей вручную: `git pull` main → `npm run build` → копирование `dist/` на хостинг ideav.ru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)