### PR TITLE
fix(seo): self-canonical на /terms.html и /acct.html (#410)

### DIFF
--- a/public/acct.html
+++ b/public/acct.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="css/libs.min.css">
     <link rel="stylesheet" href="css/style.min.css">
     <link rel="icon" href="img/favicon.svg" type="image/svg+xml">
+    <link rel="canonical" href="https://ideav.ru/acct.html" />
     <title>Платежная информация</title>
 </head>
 

--- a/public/terms.html
+++ b/public/terms.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="css/libs.min.css">
     <link rel="stylesheet" href="css/style.min.css">
     <link rel="icon" href="img/favicon.svg" type="image/svg+xml">
+    <link rel="canonical" href="https://ideav.ru/terms.html" />
     <title>Соглашение об использовании сервиса Интеграм</title>
 </head>
 

--- a/tests/issue-410-canonical-terms-acct.test.mjs
+++ b/tests/issue-410-canonical-terms-acct.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repo = new URL('..', import.meta.url).pathname
+const read = (p) => readFileSync(resolve(repo, p), 'utf8')
+
+// Регрессия #410: Яндекс.Вебмастер жаловался «Канонический адрес не указан»
+// на legacy-страницах /terms.html и /acct.html. Они лежат в public/ и
+// копируются в dist/ как есть, поэтому self-canonical должен быть прямо в них.
+const pages = [
+  { file: 'public/terms.html', url: 'https://ideav.ru/terms.html' },
+  { file: 'public/acct.html', url: 'https://ideav.ru/acct.html' },
+]
+
+for (const { file, url } of pages) {
+  test(`${file} declares a self-referential canonical`, () => {
+    const src = read(file)
+    const canonical = new RegExp(
+      `<link\\s+rel="canonical"\\s+href="${url.replace(/[.]/g, '\\$&')}"\\s*/?>`,
+    )
+    assert.match(src, canonical, `${file} must contain <link rel="canonical" href="${url}">`)
+  })
+
+  test(`${file} keeps the canonical inside <head>`, () => {
+    const src = read(file)
+    const head = src.slice(0, src.indexOf('</head>'))
+    assert.ok(head.includes('rel="canonical"'), `canonical in ${file} must be inside <head>`)
+  })
+}


### PR DESCRIPTION
Closes #410.

Яндекс.Вебмастер помечал **«Канонический адрес не указан»** на двух страницах:
- `/terms.html` — «Соглашение об использовании сервиса Интеграм»
- `/acct.html` — «Платежная информация»

Это legacy-страницы старого сайта, недавно внесённые в `public/`. В их `<head>` не было `<link rel="canonical">`.

## Что сделано
- `public/terms.html`, `public/acct.html` — добавлен self-referential canonical (после `<link rel="icon">`, перед `<title>`):
  - `<link rel="canonical" href="https://ideav.ru/terms.html" />`
  - `<link rel="canonical" href="https://ideav.ru/acct.html" />`
- Больше в файлах ничего не тронуто — ровно **+1 строка на файл**.
- `tests/issue-410-canonical-terms-acct.test.mjs` — сторожит, что canonical есть и стоит внутри `<head>` обеих страниц.

`public/` копируется в `dist/` как есть, поэтому канонический тег доедет до `ideav.ru/terms.html` и `/acct.html` при следующей сборке.

## Проверка
- `npm run build` — зелёный; canonical присутствует в `dist/terms.html` и `dist/acct.html`.
- `npm test` — 268 pass, 10 fail (все 10 — **предсуществующие**: нет `php` в окружении + известные красные #14/#16/theme/index-seo). Мои 4 теста зелёные, регрессий ноль.

## Деплой
CI/CD в репозитории нет — публикует Андрей вручную: `git pull` main → `npm run build` → копирование `dist/` на хостинг ideav.ru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)