### PR TITLE
fix(#416): on-page SEO главной — короче title, www→канонич. 301, charset, внутренние ссылки

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1" />
     <meta name="description" content="Из Excel — рабочее приложение за час. Пришлите таблицу: получите веб-приложение с формами, доступами и отчётами. Понятно бухгалтеру, логисту, начальнику цеха — без программистов, 1С и долгого внедрения." />
     <meta name="keywords" content="из excel приложение,excel в приложение,замена excel за час,приложение за час,приложение из excel,автоматизация бизнеса,гугл таблицы,создать базу данных,конструктор интеграм,интеграм,российский airtable,аналог airtable,airtable,конструктор приложений,приложение без программирования,no-code,nocode,low code,зерокод,замена excel" />
-    <title>Интеграм — конструктор приложений и баз данных из Excel за час</title>
+    <title>Интеграм — конструктор приложений из Excel за час</title>
     <script>
       (function() {
         var stored = localStorage.getItem('theme');

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -2,11 +2,27 @@
 #
 # This file is copied verbatim by Vite into dist/ and deployed to the web root,
 # so caching ships with a normal build — no server SSH required (assumes the
-# vhost allows AllowOverride FileInfo). It only sets response headers and never
-# touches rewrites/routing, so it is additive and safe.
+# vhost allows AllowOverride FileInfo — confirmed live: the deployed responses
+# already carry the compression + Cache-Control headers set below).
 #
 # NOTE: HTTP/2 cannot be enabled here — it is a server-/vhost-level directive
 # (`Protocols h2 http/1.1`). See docs/server-performance.md.
+
+# ── Canonical host + charset ────────────────────────────────────────────────
+# Advertise the document charset in the HTTP Content-Type header (not just the
+# <meta> tag) for text responses.
+AddDefaultCharset UTF-8
+
+# Redirect the www. host to the bare canonical host with a 301 so search
+# engines index a single origin. RewriteEngine/RewriteRule are FileInfo-class
+# directives, same override level as the headers above, so this ships in the
+# build the same way. Guarded by mod_rewrite so it is a no-op if the module is
+# unavailable.
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+  RewriteRule ^ https://%1%{REQUEST_URI} [L,R=301]
+</IfModule>
 
 # ── Compression ─────────────────────────────────────────────────────────────
 <IfModule mod_deflate.c>

--- a/scripts/prerender-landing.mjs
+++ b/scripts/prerender-landing.mjs
@@ -136,10 +136,13 @@ const bodyHtml = `
       <span>В реестре отечественного ПО</span>
       <strong>Реестровая запись №30872</strong>
     </p>
-    <p>
+    <nav class="lp-prerender__links" aria-label="Разделы сайта">
       <a href="/excel-to-app.html">Загрузить Excel — получить приложение</a> ·
+      <a href="/informatsionnaya-sistema.html">Что такое информационная система</a> ·
+      <a href="/agent-platforms.html">Интеграм против low-code и ИИ-агентов</a> ·
+      <a href="/catalog-matching.html">Сопоставление каталогов и прайсов</a> ·
       <a href="/knowledge-base">База знаний</a>
-    </p>
+    </nav>
   </footer>
 </article>
 <style>
@@ -159,6 +162,7 @@ const bodyHtml = `
   #lp-prerender .lp-prerender__registry strong { display: block; }
   #lp-prerender .lp-prerender__registry span { font-weight: 600; color: #1e293b; }
   #lp-prerender .lp-prerender__registry strong { margin-top: 0.15rem; font-weight: 600; }
+  #lp-prerender .lp-prerender__links { line-height: 1.9; margin: 0.75rem 0 0; }
   /* Dark colours follow the app theme (.dark on <html>, set synchronously by the
      inline <head> script from localStorage) — NOT prefers-color-scheme. The body
      background comes from the bundled CSS keyed on the same .dark class, so the


### PR DESCRIPTION
Закрывает **#416**: анализ и исправление seobility-ошибок главной страницы. Текст главной не расширяю (по ТЗ: «пусть текст на главной пока не пишет») — только структурные/техн. фиксы.

## Что сделано

**1. `<title>` слишком длинный (>580px) → короче**
`Интеграм — конструктор приложений и баз данных из Excel за час` (62 симв./602px)
→ `Интеграм — конструктор приложений из Excel за час` (**49 симв.**).
Сохранены: хук **Excel→«за час»** (его стережёт тест `index-seo-meta` «leads with Excel→приложение за час») и **«конструктор»-лид** (#402). «баз данных» остаётся в `<h1>` и `<meta keywords>`.

**2. Канонизация хоста + charset в HTTP-заголовке → `public/.htaccess`**
- `301`-редирект `www.` → голый хост (единый канонический origin — seobility flag).
- `AddDefaultCharset UTF-8` — charset в HTTP-заголовке `Content-Type`, а не только в `<meta>`.
- Директивы класса **FileInfo** (тот же override, что и уже работающие в этом файле compression/`Cache-Control` — подтверждено живыми заголовками ответа сайта), `RewriteEngine` спрятан под `<IfModule mod_rewrite.c>`.

**3. «Очень мало ссылок» → внутренняя перелинковка**
Футер пререндера для краулеров (`prerender-landing.mjs`, виден только ботам — React-SPA рисует свой) расширен **2 → 5** внутренних ссылок: `+ informatsionnaya-sistema`, `+ agent-platforms`, `+ catalog-matching`.

## Вне scope
- **Длина `<meta description>` главной** — правится в открытом **PR #414** (та же `index.html`, строка 8). Здесь не дублирую, чтобы не было конфликта; `#416` трогает только строку `<title>` (строка 10).
- **apple-touch-icon** — подходящего квадратного Интеграм-иконочного ассета в репозитории нет (единственный квадратный PNG — клиентский логотип), генерацию иконки не делаю.
- **Объём текста главной (271→800 слов)** — по ТЗ не пишу.

## Проверка
- `npm run build` — зелёный; `dist/index.html`: title 49 симв., 5 внутренних ссылок в футере.
- `node --test tests/*.test.mjs`: **новых падений нет**. `prerender-landing` (7/7) и `index-seo-meta` «Excel→час» (тест 4) — зелёные. Красные — только предсуществующие: `php -l`/intake (нет `php`), blog-redirect, theme, kb-article-#14/#16, а также `index-seo-meta` тест 3 (его title-regex `Из Excel — приложение за час \| Интеграм` не совпадал с committed-заголовком ещё с #402; description/keywords в нём проходят).

🤖 Generated with [Claude Code](https://claude.com/claude-code)