### PR TITLE
fix(seo): redirect bare-host HTTP → HTTPS in .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -26,6 +26,15 @@ DirectoryIndex index.html
   RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
   RewriteRule ^ https://%1%{REQUEST_URI} [L,R=301]
 
+  # Plain HTTP → HTTPS on the canonical (non-www) host. The www rule above
+  # already targets https://, so this only catches bare-host HTTP — every
+  # scheme+host combination lands on https://<bare> in a single 301 hop (no
+  # redirect chain). The X-Forwarded-Proto check prevents a redirect loop when
+  # TLS is terminated by an upstream proxy/CDN that reaches Apache over HTTP.
+  RewriteCond %{HTTPS} off
+  RewriteCond %{HTTP:X-Forwarded-Proto} !https
+  RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
   # Front controller: real files/dirs served as-is; everything else → index.php.
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
## Problem
Site/SEO audit flagged: **“The redirect to HTTPS for this site is not configured correctly.”**

`public/.htaccess` canonicalised only the **www** host to HTTPS. Plain `http://ideav.ru` (bare host, no `www`) was served over HTTP with no redirect, so part of the traffic stayed on insecure HTTP.

| Request | Before | After |
|---|---|---|
| `http://www.ideav.ru/x` | → `https://ideav.ru/x` ✅ | ✅ |
| `https://www.ideav.ru/x` | → `https://ideav.ru/x` ✅ | ✅ |
| `http://ideav.ru/x` | served over HTTP ❌ | → `https://ideav.ru/x` ✅ |

## Fix
Add an HTTP→HTTPS `301` **after** the www rule. Because the www rule already targets `https://`, the new rule only catches the bare host — so every scheme+host combination reaches `https://<bare>` in a **single 301 hop** (no redirect chain, which audits also penalise).

`X-Forwarded-Proto !https` guards against a redirect loop when TLS is terminated by an upstream proxy/CDN that reaches Apache over plain HTTP.

The front controller (`RewriteRule ^ index.php`) is **untouched** — platform routing (the #422 invariant) is preserved.

## Verify after deploy
```bash
curl -sI  http://ideav.ru/     | grep -i location      # → https://ideav.ru/
curl -sI  http://www.ideav.ru/ | grep -i location      # → https://ideav.ru/
curl -sIL https://ideav.ru/    | grep -iE 'HTTP/|location'   # single 200, no repeated 301 (no loop)
```

## Notes
`dist/.htaccess` is a gitignored build artifact regenerated from `public/` by `npm run build`; only the source `public/.htaccess` is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)