### PR TITLE
build: guard against shipping a .htaccess that kills the platform front controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "test": "node --test tests/*.test.mjs",
-    "build": "node scripts/generate-og-images.mjs && vite build && node scripts/prerender-knowledge-base.mjs && node scripts/prerender-excel-to-app.mjs && node scripts/prerender-agent-platforms.mjs && node scripts/prerender-catalog-matching.mjs && node scripts/prerender-information-system.mjs && node scripts/prerender-tokens.mjs && node scripts/prerender-landing.mjs",
+    "build": "node scripts/generate-og-images.mjs && vite build && node scripts/prerender-knowledge-base.mjs && node scripts/prerender-excel-to-app.mjs && node scripts/prerender-agent-platforms.mjs && node scripts/prerender-catalog-matching.mjs && node scripts/prerender-information-system.mjs && node scripts/prerender-tokens.mjs && node scripts/prerender-landing.mjs && node scripts/verify-htaccess.mjs",
     "og-images": "node scripts/generate-og-images.mjs",
     "preview": "vite preview"
   },

--- a/scripts/verify-htaccess.mjs
+++ b/scripts/verify-htaccess.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Build guard: fail the build if dist/.htaccess is missing the platform front
+ * controller.
+ *
+ * ideav.ru is served by ONE web root that hosts BOTH the marketing landing
+ * (this repo) and the Интеграм platform engine (index.php, deployed from
+ * ideav/crm). Vite copies public/.htaccess verbatim into dist/, and every
+ * manual marketing deploy overwrites the web-root .htaccess with it. index.php
+ * is NOT in this build, so if the shipped .htaccess ever drops the
+ * `RewriteRule ^ index.php` front-controller line, every /<db>/... database URL
+ * stops reaching the engine and the WHOLE platform goes offline.
+ *
+ * That is exactly what happened when a headers-only .htaccess shipped (issues
+ * #422 / #423). This guard makes that class of incident impossible to build:
+ * if the final artifact can't route the platform, `npm run build` exits non-zero
+ * and never produces a deployable dist/.
+ *
+ * Runs LAST in the build chain (after vite build + all prerender steps) so it
+ * validates the exact bytes that get uploaded.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = resolve(__dirname, '..')
+const htaccess = resolve(root, 'dist', '.htaccess')
+
+/** Invariants the shipped .htaccess MUST satisfy to keep the platform routable. */
+const REQUIRED = [
+  {
+    // mod_rewrite must be turned on or none of the RewriteRules below apply.
+    test: /^\s*RewriteEngine\s+On/mi,
+    what: 'RewriteEngine On',
+  },
+  {
+    // The front controller itself. Anchored to line start (after optional
+    // indent) so the descriptive `RewriteRule ^ index.php` inside the header
+    // comment (which starts with `#`) does not count as a match.
+    test: /^\s*RewriteRule\s+\^\s+index\.php/m,
+    what: 'RewriteRule ^ index.php  (platform front controller — see issues #422/#423)',
+  },
+]
+
+function fail(message) {
+  console.error(`\n✖ verify-htaccess: ${message}`)
+  console.error('  Refusing to ship a dist/.htaccess that would take the Интеграм')
+  console.error('  platform offline. Fix public/.htaccess and rebuild.\n')
+  process.exit(1)
+}
+
+if (!existsSync(htaccess)) {
+  fail('dist/.htaccess does not exist — the front controller would not be deployed at all.')
+}
+
+const contents = readFileSync(htaccess, 'utf8')
+const missing = REQUIRED.filter(rule => !rule.test.test(contents)).map(rule => rule.what)
+
+if (missing.length > 0) {
+  fail(`dist/.htaccess is missing required directive(s):\n    - ${missing.join('\n    - ')}`)
+}
+
+console.log('✓ verify-htaccess: dist/.htaccess carries the platform front controller.')


### PR DESCRIPTION
## Why
Twice now a marketing deploy has taken the **Интеграм platform** offline via `.htaccess` (headers-only regression #422, recovered in #423, and again during a manual build+copy).

Root cause: ideav.ru serves **both** the marketing landing (this repo) and the platform engine `index.php` (from `ideav/crm`) from **one web root**. Vite copies `public/.htaccess` verbatim into `dist/`, and every manual deploy overwrites the web-root `.htaccess` with it. `index.php` is **not** in this build — so if the shipped `.htaccess` ever drops the front-controller line:

```apache
RewriteRule ^ index.php [L,QSA]
```

every `/<db>/...` database URL stops reaching the engine and the **whole platform goes offline**.

## What
Add `scripts/verify-htaccess.mjs` as the **last** step of `npm run build`. It validates the exact bytes that get uploaded:

- `dist/.htaccess` exists,
- contains `RewriteEngine On`,
- contains the `RewriteRule ^ index.php` front controller (anchored to line start, so the mention inside the header comment does **not** count).

On any miss it prints the missing directive(s) and exits non-zero, so a broken `.htaccess` **can't be built into a deployable `dist/`**. That outage class becomes impossible to ship by mistake.

## Tested
| Case | Result |
|---|---|
| Valid `dist/.htaccess` | ✓ pass, exit 0 |
| Headers-only (no rewrite) | ✗ fail, exit 1 — flags `RewriteEngine On` + front controller |
| Front controller only in a `#` comment | ✗ fail, exit 1 — correctly not counted |

## Note
Independent of #424 (HTTP→HTTPS redirect); this PR only touches `package.json` + a new script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)