### PR TITLE
feat(#436): секция «Все решения и инструменты» на главной

### DIFF
--- a/scripts/prerender-landing.mjs
+++ b/scripts/prerender-landing.mjs
@@ -19,6 +19,7 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { USE_CASES } from '../src/data/usecases.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '..')
@@ -116,6 +117,12 @@ const faqHtml = `
           .join('\n        ')}
       </section>`
 
+// Ссылки на все страницы-решения — чтобы краулеры видели их в статичном
+// снапшоте главной, а не только после загрузки SPA (issue #436).
+const useCaseLinksHtml = USE_CASES
+  .map((u) => `<a href="/${u.slug}.html">${escape(u.badge.replace(/ на Интеграме$/, ''))}</a>`)
+  .join(' ·\n      ')
+
 const bodyHtml = `
 <article id="lp-prerender" itemscope itemtype="https://schema.org/SoftwareApplication">
   <header>
@@ -142,6 +149,12 @@ const bodyHtml = `
       <a href="/agent-platforms.html">Интеграм против low-code и ИИ-агентов</a> ·
       <a href="/catalog-matching.html">Сопоставление каталогов и прайсов</a> ·
       <a href="/knowledge-base">База знаний</a>
+    </nav>
+    <nav class="lp-prerender__links" aria-label="Решения вместо Excel">
+      <a href="/konstruktor-prilozhenij.html">Конструктор вместо Excel</a> ·
+      <a href="/resheniya.html">Все решения вместо Excel</a> ·
+      ${useCaseLinksHtml} ·
+      <a href="/tokens.html">Токены — как считается стоимость</a>
     </nav>
   </footer>
 </article>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -38,6 +38,7 @@ import {
   FileSpreadsheet
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
+import { USE_CASES } from '../data/usecases'
 import ClientLogos from '@/components/ClientLogos'
 
 declare global {
@@ -903,6 +904,64 @@ export default function Home() {
                 </div>
                 <span className="text-slate-600 dark:text-slate-300 font-medium">{task}</span>
               </motion.div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* 9c. Все решения и инструменты (issue #436) — ссылки на все страницы */}
+      <section id="solutions" className="py-24 bg-slate-50 dark:bg-slate-900/50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl md:text-4xl font-bold mb-4">Все решения и инструменты</h2>
+            <p className="text-slate-500 dark:text-slate-400">Отдельная страница под каждую задачу — от инструментов платформы до готовых решений вместо Excel</p>
+          </div>
+
+          {/* Инструменты платформы */}
+          <h3 className="text-lg font-bold mb-5 text-slate-800 dark:text-slate-100">Инструменты платформы</h3>
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mb-14">
+            {[
+              { title: 'Конструктор приложений вместо Excel', href: '/konstruktor-prilozhenij.html' },
+              { title: 'Excel → приложение за ~45 минут', href: '/excel-to-app.html' },
+              { title: 'Массовое сопоставление каталогов', href: '/catalog-matching.html' },
+              { title: 'Информационная система', href: '/informatsionnaya-sistema.html' },
+              { title: 'ИИ и агентские платформы', href: '/agent-platforms.html' },
+              { title: 'Токены: как считается стоимость', href: '/tokens.html' },
+            ].map((p, i) => (
+              <Link
+                key={i}
+                to={p.href}
+                className="group p-5 flex items-center gap-4 bg-white dark:bg-slate-900/40 border border-slate-200 dark:border-slate-800 rounded-2xl hover:border-blue-500/40 hover:shadow-sm transition-all"
+              >
+                <div className="w-8 h-8 rounded-lg bg-blue-600/10 text-blue-500 flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+                  <CheckCircle2 size={16} />
+                </div>
+                <span className="text-slate-700 dark:text-slate-200 font-medium flex-1">{p.title}</span>
+                <ArrowRight size={16} className="text-slate-300 dark:text-slate-600 group-hover:text-blue-500 group-hover:translate-x-0.5 transition-all flex-shrink-0" />
+              </Link>
+            ))}
+          </div>
+
+          {/* Решения по задачам — вместо Excel */}
+          <div className="flex flex-wrap items-center justify-between gap-3 mb-5">
+            <h3 className="text-lg font-bold text-slate-800 dark:text-slate-100">Решения по задачам — вместо Excel</h3>
+            <Link to="/resheniya.html" className="inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:gap-2 transition-all">
+              Все решения <ArrowRight size={15} />
+            </Link>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {USE_CASES.map((u) => (
+              <Link
+                key={u.slug}
+                to={`/${u.slug}.html`}
+                className="group p-5 flex items-center gap-4 bg-white dark:bg-slate-900/40 border border-slate-200 dark:border-slate-800 rounded-2xl hover:border-blue-500/40 hover:shadow-sm transition-all"
+              >
+                <div className="w-8 h-8 rounded-lg bg-blue-600/10 text-blue-500 flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+                  <CheckCircle2 size={16} />
+                </div>
+                <span className="text-slate-700 dark:text-slate-200 font-medium flex-1">{u.badge.replace(/ на Интеграме$/, '')}</span>
+                <ArrowRight size={16} className="text-slate-300 dark:text-slate-600 group-hover:text-blue-500 group-hover:translate-x-0.5 transition-all flex-shrink-0" />
+              </Link>
             ))}
           </div>
         </div>


### PR DESCRIPTION
Закрывает **#436** — «страницы есть, а ссылок на них нигде нет».

## Что сделано
Новый раздел **`#solutions`** на главной (по образцу «Готовые типы проектов» / «Для кого») со ссылками на все страницы-решения:

- **Инструменты платформы** (6): Конструктор вместо Excel, Excel → приложение, Сопоставление каталогов, Информационная система, ИИ и агентские платформы, Токены.
- **Решения по задачам — вместо Excel** (10): заявки, проекты, производство, склад, закупки, финансы, кадры, CRM, документооборот, управленческий учёт — плюс ссылка «Все решения» на хаб `/resheniya.html`.

Список ниш тянется из `src/data/usecases.mjs` (единый источник — не разъедется при добавлении тем).

## Для краулеров
Те же ссылки добавлены в **статический снапшот главной** (`prerender-landing.mjs`, footer-nav), чтобы их видел Яндекс и др., а не только SPA после JS.

## Проверено
- `npm run build` целиком, `verify-htaccess` зелёный
- `tsc --noEmit` — 0 ошибок
- В `dist/index.html` (снапшот) присутствуют все 10 ссылок на ниши + конструктор + хаб

🤖 Generated with [Claude Code](https://claude.com/claude-code)