### PR TITLE
perf(#451): ускорить первую загрузку — code-splitting (JS-бандл 1 МБ → 134 КБ)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { Suspense, useEffect } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 import { Header } from './components/Header'
 import { Footer } from './components/Footer'
@@ -29,6 +29,16 @@ function ScrollToRouteTarget() {
   return null
 }
 
+// Фолбэк на время подгрузки чанка ленивой страницы. min-h держит подвал внизу,
+// чтобы не было скачка вёрстки.
+function RouteFallback() {
+  return (
+    <div className="min-h-[70vh] flex items-center justify-center" role="status" aria-label="Загрузка">
+      <div className="h-8 w-8 rounded-full border-2 border-slate-200 dark:border-slate-700 border-t-blue-600 animate-spin" />
+    </div>
+  )
+}
+
 export default function App() {
   return (
     <ThemeProvider>
@@ -36,7 +46,9 @@ export default function App() {
         <ScrollToRouteTarget />
         <Header />
         <main>
-          <Outlet />
+          <Suspense fallback={<RouteFallback />}>
+            <Outlet />
+          </Suspense>
         </main>
         <Footer />
         <CookieConsent />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -719,6 +719,8 @@ export default function Home() {
                   <img
                     src={`${import.meta.env.BASE_URL}case-orbita-planner.png`}
                     alt="Орбита Planner — система управления строительным персоналом"
+                    loading="lazy"
+                    decoding="async"
                     className="w-full block"
                   />
                 </div>
@@ -744,6 +746,8 @@ export default function Home() {
                   <img
                     src={`${import.meta.env.BASE_URL}case-sovereignty-audit.png`}
                     alt="Аудит суверенности 9D — оценка технологической независимости портфельных компаний"
+                    loading="lazy"
+                    decoding="async"
                     className="w-full block"
                   />
                 </div>
@@ -858,6 +862,8 @@ export default function Home() {
                   </div>
                   <img
                     src={`${import.meta.env.BASE_URL}case-pdn.png`}
+                    loading="lazy"
+                    decoding="async"
                     alt="Процессы обработки персональных данных (ПДн) — реестр процессов в банке"
                     className="w-full block"
                   />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,21 +1,26 @@
+import { lazy } from 'react'
 import { createBrowserRouter } from 'react-router-dom'
 import Home from './pages/Home'
-import NotFound from './pages/NotFound'
-import Success from './pages/Success'
-import Fail from './pages/Fail'
-import ExcelToApp from './pages/ExcelToApp'
-import AgentPlatforms from './pages/AgentPlatforms'
-import CatalogMatching from './pages/CatalogMatching'
-import ExcelConstructor from './pages/ExcelConstructor'
-import InformationSystem from './pages/InformationSystem'
-import Tokens from './pages/Tokens'
-import AdImages from './pages/AdImages'
-import KnowledgeBase from './pages/KnowledgeBase'
-import KnowledgeBaseArticle from './pages/KnowledgeBaseArticle'
-import UseCaseLanding from './pages/UseCaseLanding'
-import UseCaseHub from './pages/UseCaseHub'
 import { USE_CASES } from './data/usecases'
 import App from './App'
+
+// Главная и layout грузятся сразу (самый частый вход). Остальные страницы —
+// по требованию (code-splitting), чтобы начальный бандл не тянул код всех
+// разделов и первый экран открывался быстрее (issue #451).
+const NotFound = lazy(() => import('./pages/NotFound'))
+const Success = lazy(() => import('./pages/Success'))
+const Fail = lazy(() => import('./pages/Fail'))
+const ExcelToApp = lazy(() => import('./pages/ExcelToApp'))
+const AgentPlatforms = lazy(() => import('./pages/AgentPlatforms'))
+const CatalogMatching = lazy(() => import('./pages/CatalogMatching'))
+const ExcelConstructor = lazy(() => import('./pages/ExcelConstructor'))
+const InformationSystem = lazy(() => import('./pages/InformationSystem'))
+const Tokens = lazy(() => import('./pages/Tokens'))
+const AdImages = lazy(() => import('./pages/AdImages'))
+const KnowledgeBase = lazy(() => import('./pages/KnowledgeBase'))
+const KnowledgeBaseArticle = lazy(() => import('./pages/KnowledgeBaseArticle'))
+const UseCaseLanding = lazy(() => import('./pages/UseCaseLanding'))
+const UseCaseHub = lazy(() => import('./pages/UseCaseHub'))
 
 export const router = createBrowserRouter([
   {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,21 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
-  
+
+  // Разбиваем сборку: тяжёлые вендоры — в отдельные кэшируемые чанки, а код
+  // страниц уходит в свои чанки через lazy() в router.tsx. Так первый экран
+  // не тянет весь код сайта одним ~1 МБ файлом (issue #451).
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          'motion': ['framer-motion'],
+        },
+      },
+    },
+  },
+
   // Кэш и временные файлы Vite хранятся в проекте, а не в node_modules
   // потому что node_modules может быть symlink на readonly папку
   cacheDir: '.vite',


### PR DESCRIPTION
Issue #451 — «вначале вижу голую страницу, долго грузится».

## Диагноз (по скриншоту DevTools из issue)
Начальный экран показывал неоформленный снапшот пререндера **~7 секунд**, пока грузился **один монолитный JS-бандл ~1 МБ** (`index-…js` — 1 046 КБ, 7.03 с). Причина: `router.tsx` статически импортировал **все** страницы сайта, поэтому главная тянула код всех разделов + данные базы знаний.

## Что сделано
- **`router.tsx`** — все страницы, кроме главной и layout, через `React.lazy()` → каждая в своём чанке, грузится по требованию.
- **`App.tsx`** — `<Suspense>` вокруг `<Outlet>` с ненавязчивым спиннером на время подгрузки чанка.
- **`vite.config.ts`** — `manualChunks`: `react`/`react-dom`/`react-router-dom` и `framer-motion` вынесены в отдельные **кэшируемые** вендор-чанки.
- **`Home.tsx`** — три скриншота-кейса (~600 КБ) получили `loading="lazy"` + `decoding="async"` (они глубоко под сгибом).

## Результат сборки
| | Было | Стало |
| :--- | ---: | ---: |
| Начальный чанк главной | **1 046 КБ** | **134 КБ** (34 КБ gzip) |
| react-vendor (кэш) | — | 230 КБ |
| framer-motion (кэш) | — | 125 КБ |
| Данные базы знаний | в общем бандле | 176 КБ, только на страницах ББ |
| Код разделов (CatalogMatching, ExcelToApp…) | в общем бандле | свои чанки по требованию |

Предупреждение сборки «chunk > 500 КБ» ушло.

## Проверено
`tsc --noEmit` без ошибок; `npm run build` проходит (все пререндеры + verify-htaccess); главная рендерится сразу и стилизованно (без «голого» мелькания), ленивые страницы подгружаются и рендерятся корректно (playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)