### PR TITLE
fix(#453): убрать ссылки на внутренние тикеты внизу статей базы знаний

### DIFF
--- a/src/pages/KnowledgeBaseArticle.tsx
+++ b/src/pages/KnowledgeBaseArticle.tsx
@@ -470,19 +470,6 @@ export default function KnowledgeBaseArticle() {
               </ul>
             </section>
           )}
-
-          <div className="text-xs text-slate-400 dark:text-slate-500 italic">
-            Исходный материал статьи и фактчек —{' '}
-            <a
-              href={article.sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 underline hover:text-blue-500 dark:hover:text-blue-400 not-italic"
-            >
-              в репозитории ideav/crm <ExternalLink size={11} />
-            </a>
-            .
-          </div>
         </div>
       </article>
 


### PR DESCRIPTION
## Проблема (#453)

Внизу каждой статьи базы знаний висел блок:

> Исходный материал статьи и фактчек — **в репозитории ideav/crm** ↗

Ссылка вела на внутренние тикеты (напр. `github.com/ideav/backlogram/issues/426`), которые на публичном сайте выглядят неопрятно и не нужны посетителям.

Пример страницы: `/knowledge-base/23-security-fault-tolerance.html`

## Что сделано

- Удалён футер-блок «Исходный материал статьи и фактчек…» из `src/pages/KnowledgeBaseArticle.tsx` — он рендерился на **всех** статьях базы знаний.
- Раздел **«Источники»** и импорт `ExternalLink` не тронуты (используются там же).
- Поле `sourceUrl` в данных статей оставлено как есть — оно больше нигде не рендерится, править 26 статей смысла нет.

## Проверка

- `tsc --noEmit` — без ошибок
- `npm run build` — успешно, 26 статей пререндерятся, `verify-htaccess` проходит
- В `dist/` фраза «Исходный материал статьи и фактчек» отсутствует полностью; в бандле остаются только легитимные упоминания «ideav/crm» внутри текста самих статей и раздела «Источники».

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)