### PR TITLE
fix(#467): пустая форма не засчитывается как конверсия (Метрика-автоцель «Отправка формы»)

### DIFF
--- a/src/pages/CatalogMatching.tsx
+++ b/src/pages/CatalogMatching.tsx
@@ -731,9 +731,13 @@ export default function CatalogMatching() {
               </div>
               <div>
                 <label className="block text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2 ml-1">Email / Telegram</label>
+                {/* required гасит submit-событие для пустого контакта, чтобы автоцель
+                    Метрики «Отправка формы» не засчитала пустую заявку (issue #467). */}
                 <input
                   name="contact"
                   type="text"
+                  required
+                  onInvalid={e => { e.preventDefault(); setFormState('error'); setErrorMsg('Укажите контакт — email или Telegram, куда прислать результат.') }}
                   onInput={() => setIsCaptchaRequested(true)}
                   className="w-full bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-2.5 text-slate-800 dark:text-slate-100 focus:border-blue-500 outline-none transition-all"
                   placeholder="@username или you@company.ru"

--- a/src/pages/ExcelConstructor.tsx
+++ b/src/pages/ExcelConstructor.tsx
@@ -671,9 +671,18 @@ export default function ExcelConstructor() {
               </div>
               <div>
                 <label className="block text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2 ml-1">Email / Telegram</label>
+                {/*
+                  Пустой контакт гасим НАТИВНОЙ проверкой required (issue #467): без
+                  неё отправка, отменённая через preventDefault, всё равно порождает
+                  submit-событие, и автоцель Метрики «Отправка формы» засчитывает его
+                  как конверсию. required не даёт submit-событию возникнуть; свой текст
+                  показываем вместо системного «пузыря».
+                */}
                 <input
                   name="contact"
                   type="text"
+                  required
+                  onInvalid={e => { e.preventDefault(); setFormState('error'); setErrorMsg('Укажите контакт — email или Telegram, куда прислать демо-доступ.') }}
                   onInput={() => setIsCaptchaRequested(true)}
                   className="w-full bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-2.5 text-slate-800 dark:text-slate-100 focus:border-blue-500 outline-none transition-all"
                   placeholder="@username или you@company.ru"

--- a/src/pages/ExcelToApp.tsx
+++ b/src/pages/ExcelToApp.tsx
@@ -765,7 +765,7 @@ export default function ExcelToApp() {
                 </button>
               </div>
             ) : (
-              <form className="space-y-6" onSubmit={handleSubmit} noValidate>
+              <form className="space-y-6" onSubmit={handleSubmit}>
                 <div>
                   <h2 className="text-2xl md:text-3xl font-bold mb-2">Загрузите свои таблицы</h2>
                   <p className="text-slate-500 dark:text-slate-400">
@@ -859,11 +859,16 @@ export default function ExcelToApp() {
                   <label htmlFor="excel-contact" className="block text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2 ml-1">
                     Контакт — email или Telegram
                   </label>
+                  {/* required гасит submit-событие для пустого контакта, чтобы автоцель
+                      Метрики «Отправка формы» не засчитала пустую заявку (issue #467).
+                      Ради этого с <form> снят noValidate. */}
                   <input
                     id="excel-contact"
                     name="contact"
                     type="text"
+                    required
                     value={contact}
+                    onInvalid={e => { e.preventDefault(); setFormState('error'); setErrorMsg('Укажите контакт — email или Telegram, куда пришлем ссылку.') }}
                     onInput={() => setIsCaptchaRequested(true)}
                     onChange={e => setContact(e.target.value)}
                     className="w-full bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-3 text-slate-800 dark:text-slate-100 focus:border-blue-500 outline-none transition-all"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1162,7 +1162,9 @@ export default function Home() {
                 </div>
                 <div>
                   <label className="block text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2 ml-1">Email / Telegram</label>
-                  <input name="contact" type="text" onInput={() => setIsCaptchaRequested(true)} className="w-full bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-2 sm:py-3 text-slate-800 dark:text-slate-100 focus:border-blue-500 outline-none transition-all" placeholder="@username" />
+                  {/* required гасит submit-событие для пустого контакта, чтобы автоцель
+                      Метрики «Отправка формы» не засчитала пустую заявку (issue #467). */}
+                  <input name="contact" type="text" required onInvalid={e => { e.preventDefault(); setFormState('error'); setErrorMsg('Укажите контакт — email или Telegram, куда прислать оценку.') }} onInput={() => setIsCaptchaRequested(true)} className="w-full bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-2 sm:py-3 text-slate-800 dark:text-slate-100 focus:border-blue-500 outline-none transition-all" placeholder="@username" />
                 </div>
                 <div>
                   <label className="block text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2 ml-1">Задача (коротко)</label>

--- a/src/pages/UseCaseLanding.tsx
+++ b/src/pages/UseCaseLanding.tsx
@@ -398,7 +398,9 @@ export default function UseCaseLanding({ slug }: { slug: string }) {
               </div>
               <div>
                 <label className="block text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2 ml-1">Email / Telegram</label>
-                <input name="contact" type="text" onInput={() => setIsCaptchaRequested(true)} placeholder="@username или you@company.ru"
+                {/* required гасит submit-событие для пустого контакта, чтобы автоцель
+                    Метрики «Отправка формы» не засчитала пустую заявку (issue #467). */}
+                <input name="contact" type="text" required onInvalid={e => { e.preventDefault(); setFormState('error'); setErrorMsg('Укажите контакт — email или Telegram, куда прислать демо-доступ.') }} onInput={() => setIsCaptchaRequested(true)} placeholder="@username или you@company.ru"
                   className="w-full bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-2.5 text-slate-800 dark:text-slate-100 focus:border-blue-500 outline-none transition-all" />
               </div>
               <div>


### PR DESCRIPTION
Closes #467

## Проблема
Попытка отправить форму-заявку с пустым контактом (см. скриншот в тикете: имя и компания заполнены, «Email / Telegram» пусто → ошибка «Укажите контакт…») **засчитывалась в Метрике как конверсия**.

Причина — **не** в JS-цели `lead`: она уходит только на успешный ответ сервера (`reachGoal('lead')` внутри `if (res.ok && json.ok)` во всех формах). Виновата **автоцель Метрики «Отправка формы»**: она вешается на `submit`-событие формы и засчитывает его, **даже когда** обработчик вызывает `e.preventDefault()` и выходит по собственной валидации. То есть каждый клик по «Заказать демо» с пустым контактом = ложная конверсия (автоцель считает и повторные клики). Это известное поведение автоцели ([Клуб Яндекс.Метрики](https://yandex.ru/blog/metrika-club/kak-pravilno-nastroit-reachgoal-v-formakh), [разбор](https://gaga-analyze.ru/autogoal-yandex-metrika/)); рекомендация — не давать форме отправляться при невалидных данных.

## Фикс
Полю контакта во всех формах-заявках добавлен нативный **`required`**. При пустом контакте браузер прерывает отправку **до** возникновения `submit`-события — автоцель его не видит, конверсия не засчитывается. Обработчик **`onInvalid`** гасит системный «пузырёк» (`preventDefault`) и показывает **прежнее** пользовательское сообщение «Укажите контакт — …», так что UX не меняется. С формы `ExcelToApp` снят `noValidate` (иначе нативная проверка отключена).

Валидный контакт по-прежнему порождает `submit`-событие и настоящую конверсию.

Затронуты все 5 форм-заявок: `Home`, `ExcelConstructor` (`/konstruktor-prilozhenij`), `ExcelToApp`, `CatalogMatching`, `UseCaseLanding`.

## Проверка (браузер, `vite preview`)
На страницу навешен спай на `document` `submit` (capture) — ровно то, что слушает автоцель Метрики:

| Сценарий | submit-событий | POST | Итог |
|---|---:|---:|---|
| Контакт пуст (баг из тикета) | **0** | 0 | автоцель не сработает; показано своё сообщение; нативный «пузырёк» подавлен |
| Контакт заполнен | **1** | идёт отправка | настоящая заявка/конверсия сохранена |

`tsc --noEmit` и `vite build` — зелёные. `node --test tests/*.test.mjs` — набор падений идентичен baseline (предсуществующие: нет `php`, частичный `dist`), **новых падений мой diff не вносит**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)