### PR TITLE
feat(#477): хлебные крошки на продуктовых и use-case лендингах

### DIFF
--- a/scripts/prerender-agent-platforms.mjs
+++ b/scripts/prerender-agent-platforms.mjs
@@ -239,6 +239,15 @@ const jsonLd = {
       author: { '@id': `${SITE}/#organization` },
       publisher: { '@id': `${SITE}/#organization` },
     },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${canonical}#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Интеграм', item: `${SITE}/` },
+        { '@type': 'ListItem', position: 2, name: 'Из Excel — приложение', item: `${SITE}/excel-to-app.html` },
+        { '@type': 'ListItem', position: 3, name: 'ИИ-агент собирает приложение', item: canonical },
+      ],
+    },
   ],
 }
 

--- a/scripts/prerender-catalog-matching.mjs
+++ b/scripts/prerender-catalog-matching.mjs
@@ -195,6 +195,14 @@ const jsonLd = {
       author: { '@id': `${SITE}/#organization` },
       publisher: { '@id': `${SITE}/#organization` },
     },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${canonical}#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Интеграм', item: `${SITE}/` },
+        { '@type': 'ListItem', position: 2, name: 'Сопоставление каталогов', item: canonical },
+      ],
+    },
   ],
 }
 

--- a/scripts/prerender-excel-to-app.mjs
+++ b/scripts/prerender-excel-to-app.mjs
@@ -201,6 +201,14 @@ const jsonLd = {
         acceptedAnswer: { '@type': 'Answer', text: f.a },
       })),
     },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${canonical}#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Интеграм', item: `${SITE}/` },
+        { '@type': 'ListItem', position: 2, name: 'Из Excel — приложение', item: canonical },
+      ],
+    },
   ],
 }
 

--- a/scripts/prerender-information-system.mjs
+++ b/scripts/prerender-information-system.mjs
@@ -272,6 +272,14 @@ const jsonLd = {
         acceptedAnswer: { '@type': 'Answer', text: f.a },
       })),
     },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${canonical}#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Интеграм', item: `${SITE}/` },
+        { '@type': 'ListItem', position: 2, name: 'Информационная система', item: canonical },
+      ],
+    },
   ],
 }
 

--- a/scripts/prerender-konstruktor-prilozhenij.mjs
+++ b/scripts/prerender-konstruktor-prilozhenij.mjs
@@ -229,6 +229,14 @@ const jsonLd = {
         acceptedAnswer: { '@type': 'Answer', text: f.a },
       })),
     },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${canonical}#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Интеграм', item: `${SITE}/` },
+        { '@type': 'ListItem', position: 2, name: 'Конструктор приложений', item: canonical },
+      ],
+    },
   ],
 }
 

--- a/scripts/prerender-sravnenie.mjs
+++ b/scripts/prerender-sravnenie.mjs
@@ -222,6 +222,15 @@ const jsonLd = {
         acceptedAnswer: { '@type': 'Answer', text: f.a },
       })),
     },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${canonical}#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Интеграм', item: `${SITE}/` },
+        { '@type': 'ListItem', position: 2, name: 'CRM-учёт клиентов', item: `${SITE}/crm-uchet-klientov.html` },
+        { '@type': 'ListItem', position: 3, name: 'Сравнение с Битрикс24 и amoCRM', item: canonical },
+      ],
+    },
   ],
 }
 

--- a/scripts/prerender-tokens.mjs
+++ b/scripts/prerender-tokens.mjs
@@ -136,13 +136,25 @@ const ogImage = `${SITE}/og/home.png`
 
 const jsonLd = {
   '@context': 'https://schema.org',
-  '@type': 'WebPage',
-  '@id': `${canonical}#webpage`,
-  url: canonical,
-  name: ogTitle,
-  description: ogDescription,
-  inLanguage: 'ru',
-  isPartOf: { '@id': `${SITE}/#website` },
+  '@graph': [
+    {
+      '@type': 'WebPage',
+      '@id': `${canonical}#webpage`,
+      url: canonical,
+      name: ogTitle,
+      description: ogDescription,
+      inLanguage: 'ru',
+      isPartOf: { '@id': `${SITE}/#website` },
+    },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${canonical}#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Интеграм', item: `${SITE}/` },
+        { '@type': 'ListItem', position: 2, name: 'Токены и стоимость', item: canonical },
+      ],
+    },
+  ],
 }
 
 const headTags = [

--- a/scripts/prerender-usecases.mjs
+++ b/scripts/prerender-usecases.mjs
@@ -164,6 +164,14 @@ for (const uc of USE_CASES) {
       { '@type': 'WebPage', '@id': `${canonical}#webpage`, url: canonical, name: uc.ogTitle, description: uc.ogDescription, inLanguage: 'ru', isPartOf: { '@id': `${SITE}/#website` } },
       { '@type': 'Service', '@id': `${canonical}#service`, name: uc.badge, serviceType: uc.seoTitle, provider: { '@id': `${SITE}/#organization` }, areaServed: 'RU', url: canonical, description: uc.ogDescription },
       { '@type': 'FAQPage', '@id': `${canonical}#faq`, mainEntity: uc.faq.map((f) => ({ '@type': 'Question', name: f.q, acceptedAnswer: { '@type': 'Answer', text: f.a } })) },
+      {
+        '@type': 'BreadcrumbList', '@id': `${canonical}#breadcrumb`,
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Интеграм', item: `${SITE}/` },
+          { '@type': 'ListItem', position: 2, name: 'Решения', item: `${SITE}/resheniya.html` },
+          { '@type': 'ListItem', position: 3, name: uc.badge.replace(/\s+на Интеграме$/, ''), item: canonical },
+        ],
+      },
     ],
   }
   const sz = IMG_SIZE[uc.image] ?? { w: 1200, h: 630 }
@@ -203,6 +211,13 @@ for (const uc of USE_CASES) {
         itemListElement: USE_CASES.map((u, i) => ({
           '@type': 'ListItem', position: i + 1, name: u.badge, url: `${SITE}/${u.slug}.html`,
         })),
+      },
+      {
+        '@type': 'BreadcrumbList', '@id': `${canonical}#breadcrumb`,
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Интеграм', item: `${SITE}/` },
+          { '@type': 'ListItem', position: 2, name: 'Решения', item: canonical },
+        ],
       },
     ],
   }

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,62 @@
+import { Link } from 'react-router-dom'
+import { ChevronRight } from 'lucide-react'
+
+export interface Crumb {
+  /** Отображаемое имя звена. */
+  name: string
+  /** Абсолютный путь маршрута, напр. "/" или "/excel-to-app.html". */
+  to: string
+}
+
+/**
+ * Хлебные крошки для продуктовых лендингов (issue #477).
+ *
+ * Рендерит доступную навигационную цепочку «Интеграм / … / текущая страница».
+ * Последнее звено — текущая страница (не ссылка, aria-current="page"); все
+ * предыдущие — ссылки на родительские разделы.
+ *
+ * Структурированные данные (BreadcrumbList JSON-LD) для поисковиков живут в
+ * пререндер-снапшоте страницы (scripts/prerender-*.mjs) — там же, где остальной
+ * JSON-LD, — чтобы их видели и краулеры без JS (Яндекс). Здесь только видимая
+ * навигация для пользователей и JS-краулеров, поэтому дублей разметки нет.
+ */
+export default function Breadcrumbs({
+  items,
+  className = '',
+}: {
+  items: Crumb[]
+  className?: string
+}) {
+  return (
+    <nav aria-label="Хлебные крошки" className={`mb-6 ${className}`}>
+      <ol className="flex w-fit flex-wrap items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500">
+        {items.map((item, i) => {
+          const isLast = i === items.length - 1
+          return (
+            <li key={item.to} className="flex items-center gap-1.5">
+              {isLast ? (
+                <span
+                  aria-current="page"
+                  className="font-medium text-slate-600 dark:text-slate-300"
+                >
+                  {item.name}
+                </span>
+              ) : (
+                <>
+                  <Link to={item.to} className="transition-colors hover:text-blue-500">
+                    {item.name}
+                  </Link>
+                  <ChevronRight
+                    size={14}
+                    className="shrink-0 text-slate-300 dark:text-slate-600"
+                    aria-hidden="true"
+                  />
+                </>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/src/pages/AgentPlatforms.tsx
+++ b/src/pages/AgentPlatforms.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
-  ArrowLeft,
   ArrowRight,
   CheckCircle2,
   AlertTriangle,
@@ -24,6 +23,7 @@ import {
   Building2,
   Terminal,
 } from 'lucide-react'
+import Breadcrumbs from '../components/Breadcrumbs'
 
 const SITE = 'https://ideav.ru'
 const PATH = '/agent-platforms.html'
@@ -248,12 +248,13 @@ export default function AgentPlatforms() {
       {/* Hero */}
       <section className="pt-28 pb-12 lg:pt-36 lg:pb-16 border-b border-slate-200 dark:border-slate-900">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link
-            to="/excel-to-app.html"
-            className="inline-flex items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
-          >
-            <ArrowLeft size={16} /> Назад к «Excel → приложение»
-          </Link>
+          <Breadcrumbs
+            items={[
+              { name: 'Интеграм', to: '/' },
+              { name: 'Из Excel — приложение', to: '/excel-to-app.html' },
+              { name: 'ИИ-агент собирает приложение', to: '/agent-platforms.html' },
+            ]}
+          />
 
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-5">
             <Bot size={14} />

--- a/src/pages/BitrixAmoComparison.tsx
+++ b/src/pages/BitrixAmoComparison.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
-  ArrowLeft,
   ArrowRight,
   CheckCircle2,
   XCircle,
@@ -20,6 +19,7 @@ import {
   User,
   Wallet,
 } from 'lucide-react'
+import Breadcrumbs from '../components/Breadcrumbs'
 import { Logo } from '../components/Logo'
 
 const SITE = 'https://ideav.ru'
@@ -184,12 +184,13 @@ export default function BitrixAmoComparison() {
       {/* Hero */}
       <section className="pt-28 pb-12 lg:pt-36 lg:pb-16 border-b border-slate-200 dark:border-slate-900">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link
-            to="/crm-uchet-klientov.html"
-            className="flex w-fit items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
-          >
-            <ArrowLeft size={16} /> CRM-учёт клиентов на Интеграме
-          </Link>
+          <Breadcrumbs
+            items={[
+              { name: 'Интеграм', to: '/' },
+              { name: 'CRM-учёт клиентов', to: '/crm-uchet-klientov.html' },
+              { name: 'Сравнение с Битрикс24 и amoCRM', to: '/sravnenie-s-bitrix-amocrm.html' },
+            ]}
+          />
 
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-5">
             <GitCompare size={14} />

--- a/src/pages/CatalogMatching.tsx
+++ b/src/pages/CatalogMatching.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
-  ArrowLeft,
   ArrowRight,
   CheckCircle2,
   AlertTriangle,
@@ -23,6 +22,7 @@ import {
   Paperclip,
   Trash2,
 } from 'lucide-react'
+import Breadcrumbs from '../components/Breadcrumbs'
 import { reachGoal } from '../lib/metrika'
 
 declare global {
@@ -433,12 +433,12 @@ export default function CatalogMatching() {
       {/* Hero */}
       <section className="pt-28 pb-12 lg:pt-36 lg:pb-16 border-b border-slate-200 dark:border-slate-900">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link
-            to="/knowledge-base.html"
-            className="flex w-fit items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
-          >
-            <ArrowLeft size={16} /> К базе знаний
-          </Link>
+          <Breadcrumbs
+            items={[
+              { name: 'Интеграм', to: '/' },
+              { name: 'Сопоставление каталогов', to: '/catalog-matching.html' },
+            ]}
+          />
 
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-5">
             <GitCompare size={14} />

--- a/src/pages/ExcelConstructor.tsx
+++ b/src/pages/ExcelConstructor.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
-  ArrowLeft,
   ArrowRight,
   CheckCircle2,
   AlertTriangle,
@@ -22,6 +21,7 @@ import {
   Paperclip,
   Trash2,
 } from 'lucide-react'
+import Breadcrumbs from '../components/Breadcrumbs'
 import { reachGoal } from '../lib/metrika'
 
 declare global {
@@ -421,12 +421,12 @@ export default function ExcelConstructor() {
       {/* Hero */}
       <section className="pt-28 pb-12 lg:pt-36 lg:pb-16 border-b border-slate-200 dark:border-slate-900">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link
-            to="/"
-            className="flex w-fit items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
-          >
-            <ArrowLeft size={16} /> На главную
-          </Link>
+          <Breadcrumbs
+            items={[
+              { name: 'Интеграм', to: '/' },
+              { name: 'Конструктор приложений', to: '/konstruktor-prilozhenij.html' },
+            ]}
+          />
 
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-5">
             <Zap size={14} />

--- a/src/pages/ExcelToApp.tsx
+++ b/src/pages/ExcelToApp.tsx
@@ -25,6 +25,7 @@ import {
   AlertTriangle,
 } from 'lucide-react'
 import { Link, useLocation } from 'react-router-dom'
+import Breadcrumbs from '../components/Breadcrumbs'
 
 declare global {
   interface Window {
@@ -495,6 +496,13 @@ export default function ExcelToApp() {
         </div>
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <Breadcrumbs
+            className="flex justify-center"
+            items={[
+              { name: 'Интеграм', to: '/' },
+              { name: 'Из Excel — приложение', to: '/excel-to-app.html' },
+            ]}
+          />
           <motion.div
             initial={{ y: 20, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}

--- a/src/pages/InformationSystem.tsx
+++ b/src/pages/InformationSystem.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
-  ArrowLeft,
   ArrowRight,
   CheckCircle2,
   AlertTriangle,
@@ -26,6 +25,7 @@ import {
   KeyRound,
   FileCode2,
 } from 'lucide-react'
+import Breadcrumbs from '../components/Breadcrumbs'
 
 const SITE = 'https://ideav.ru'
 const PATH = '/informatsionnaya-sistema.html'
@@ -304,12 +304,12 @@ export default function InformationSystem() {
       {/* Hero */}
       <section className="pt-28 pb-12 lg:pt-36 lg:pb-16 border-b border-slate-200 dark:border-slate-900">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link
-            to="/"
-            className="flex w-fit items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6"
-          >
-            <ArrowLeft size={16} /> На главную
-          </Link>
+          <Breadcrumbs
+            items={[
+              { name: 'Интеграм', to: '/' },
+              { name: 'Информационная система', to: '/informatsionnaya-sistema.html' },
+            ]}
+          />
 
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-5">
             <BookOpen size={14} />

--- a/src/pages/Tokens.tsx
+++ b/src/pages/Tokens.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion'
 import { Zap, ArrowRight, Users, Clock } from 'lucide-react'
+import Breadcrumbs from '../components/Breadcrumbs'
 
 export default function Tokens() {
   const actionCosts = [
@@ -35,6 +36,13 @@ export default function Tokens() {
       {/* Action costs table */}
       <section className="py-24">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Breadcrumbs
+            className="flex justify-center"
+            items={[
+              { name: 'Интеграм', to: '/' },
+              { name: 'Токены и стоимость', to: '/tokens.html' },
+            ]}
+          />
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold mb-4">Почему стоимость в токенах</h2>
             <p className="text-slate-500 dark:text-slate-400 max-w-2xl mx-auto">

--- a/src/pages/UseCaseHub.tsx
+++ b/src/pages/UseCaseHub.tsx
@@ -2,10 +2,11 @@ import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
-  ArrowLeft, ArrowRight, Boxes, Database, ListChecks, Layers, Settings2,
+  ArrowRight, Boxes, Database, ListChecks, Layers, Settings2,
   GitCompare, Wallet, Users, TrendingUp, Archive, BarChart3,
 } from 'lucide-react'
 import { HUB, USE_CASES } from '../data/usecases'
+import Breadcrumbs from '../components/Breadcrumbs'
 
 const SITE = 'https://ideav.ru'
 
@@ -53,9 +54,12 @@ export default function UseCaseHub() {
     <div className="overflow-hidden">
       <section className="pt-28 pb-12 lg:pt-36 lg:pb-16 border-b border-slate-200 dark:border-slate-900">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/" className="flex w-fit items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6">
-            <ArrowLeft size={16} /> На главную
-          </Link>
+          <Breadcrumbs
+            items={[
+              { name: 'Интеграм', to: '/' },
+              { name: 'Решения', to: '/resheniya.html' },
+            ]}
+          />
           <motion.h1 initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}
             className="text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight mb-5">
             {HUB.h1} <span className="text-blue-500">{HUB.h1accent}</span>

--- a/src/pages/UseCaseLanding.tsx
+++ b/src/pages/UseCaseLanding.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
-  ArrowLeft,
   ArrowRight,
   ArrowLeftRight,
   CheckCircle2,
@@ -28,6 +27,7 @@ import {
   Clock,
   Archive,
 } from 'lucide-react'
+import Breadcrumbs from '../components/Breadcrumbs'
 import { reachGoal } from '../lib/metrika'
 import { USE_CASES } from '../data/usecases'
 import type { UseCase } from '../data/usecases'
@@ -239,9 +239,13 @@ export default function UseCaseLanding({ slug }: { slug: string }) {
       {/* Hero */}
       <section className="pt-28 pb-12 lg:pt-36 lg:pb-16 border-b border-slate-200 dark:border-slate-900">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resheniya.html" className="flex w-fit items-center gap-1.5 text-sm text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors mb-6">
-            <ArrowLeft size={16} /> Все решения вместо Excel
-          </Link>
+          <Breadcrumbs
+            items={[
+              { name: 'Интеграм', to: '/' },
+              { name: 'Решения', to: '/resheniya.html' },
+              { name: uc.badge.replace(/\s+на Интеграме$/, ''), to: `/${uc.slug}.html` },
+            ]}
+          />
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-5">
             <Icon name={uc.badgeIcon} size={14} /> {uc.badge}
           </div>

--- a/tests/issue-408-information-system-breadcrumb.test.mjs
+++ b/tests/issue-408-information-system-breadcrumb.test.mjs
@@ -8,26 +8,21 @@ const read = (p) => readFileSync(resolve(repo, p), 'utf8')
 
 const pageSource = read('src/pages/InformationSystem.tsx')
 
-// Вырезаем блок ссылки «← На главную» из хедера пиллар-страницы.
-function backLinkClass() {
-  const match = pageSource.match(
-    /<Link\s+to="\/"\s+className="([^"]*)"[\s\S]*?На главную/,
+// #477: у пиллар-страницы «Информационная система» ссылку «← На главную» заменили
+// на общие хлебные крошки (Интеграм / Информационная система). Крошки покрывают и
+// роль «наверх» (первое звено Интеграм → /), и снимают регрессию #408/#385, где
+// back-link слипался с бейджем «Основы…» — теперь это отдельный блочный <nav>.
+test('the page uses the shared Breadcrumbs trail instead of an ad-hoc back-link', () => {
+  assert.match(pageSource, /import Breadcrumbs from '\.\.\/components\/Breadcrumbs'/)
+  assert.match(
+    pageSource,
+    /<Breadcrumbs[\s\S]*?name: 'Информационная система', to: '\/informatsionnaya-sistema\.html'/,
+    'InformationSystem must render a breadcrumb ending on the current page',
   )
-  assert.ok(match, 'InformationSystem should have a "На главную" back-link')
-  return match[1]
-}
-
-// Регрессия #408 / #385: ссылка «На главную» и бейдж «Основы…» слипались,
-// потому что оба были inline-flex и садились в одну строку без отступа.
-// Ссылка должна быть блочной (flex w-fit) — тогда бейдж уходит на строку ниже.
-test('«На главную» back-link is block-level so it cannot glue to the badge', () => {
-  const cls = backLinkClass()
-  assert.match(cls, /\bflex\b/, 'back-link must be a flex (block-level) element')
-  assert.match(cls, /\bw-fit\b/, 'back-link must hug its content with w-fit')
   assert.doesNotMatch(
-    cls,
-    /\binline-flex\b/,
-    'back-link must NOT be inline-flex — that glues it to the «Основы…» badge',
+    pageSource,
+    /<ArrowLeft size=\{16\} \/> На главную/,
+    'the ad-hoc «На главную» back-link must be gone (replaced by the breadcrumb)',
   )
 })
 

--- a/tests/issue-477-landing-breadcrumbs.test.mjs
+++ b/tests/issue-477-landing-breadcrumbs.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, cpSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+// #477 (SEO-структура): у продуктовых и use-case лендингов появились хлебные
+// крошки. Видимая цепочка — общий React-компонент Breadcrumbs; структурированные
+// данные (BreadcrumbList JSON-LD) живут в пререндер-снапшотах, чтобы их видели и
+// краулеры без JS (Яндекс).
+const repo = new URL('..', import.meta.url).pathname
+const read = (p) => readFileSync(resolve(repo, p), 'utf8')
+
+test('Breadcrumbs component renders an accessible nav with a current page', () => {
+  const src = read('src/components/Breadcrumbs.tsx')
+  assert.match(src, /aria-label="Хлебные крошки"/)
+  assert.match(src, /aria-current="page"/)
+  assert.match(src, /from 'react-router-dom'/)
+})
+
+// Каждый продуктовый / use-case лендинг использует общий компонент крошек,
+// а первое звено ведёт на главную (Интеграм → /).
+const LANDINGS = [
+  'src/pages/ExcelToApp.tsx',
+  'src/pages/AgentPlatforms.tsx',
+  'src/pages/CatalogMatching.tsx',
+  'src/pages/ExcelConstructor.tsx',
+  'src/pages/InformationSystem.tsx',
+  'src/pages/BitrixAmoComparison.tsx',
+  'src/pages/Tokens.tsx',
+  'src/pages/UseCaseHub.tsx',
+  'src/pages/UseCaseLanding.tsx',
+]
+for (const page of LANDINGS) {
+  test(`${page} renders visible breadcrumbs`, () => {
+    const src = read(page)
+    assert.match(src, /import Breadcrumbs from '\.\.\/components\/Breadcrumbs'/)
+    assert.match(src, /<Breadcrumbs\b/)
+    assert.match(src, /name: 'Интеграм', to: '\/'/)
+  })
+}
+
+// Пререндер-скрипты продуктовых страниц несут BreadcrumbList в статическом JSON-LD.
+const PRERENDERS = [
+  'scripts/prerender-excel-to-app.mjs',
+  'scripts/prerender-agent-platforms.mjs',
+  'scripts/prerender-catalog-matching.mjs',
+  'scripts/prerender-information-system.mjs',
+  'scripts/prerender-sravnenie.mjs',
+  'scripts/prerender-konstruktor-prilozhenij.mjs',
+  'scripts/prerender-usecases.mjs',
+  'scripts/prerender-tokens.mjs',
+]
+for (const script of PRERENDERS) {
+  test(`${script} injects BreadcrumbList structured data`, () => {
+    assert.match(read(script), /'@type': 'BreadcrumbList'/)
+  })
+}
+
+// Интеграционная проверка: BreadcrumbList реально попадает в готовый HTML.
+test('prerender emits BreadcrumbList JSON-LD into dist/excel-to-app.html', () => {
+  const indexHtml = read('index.html')
+  const work = mkdtempSync(resolve(tmpdir(), 'bc-prerender-'))
+  mkdirSync(resolve(work, 'dist'), { recursive: true })
+  mkdirSync(resolve(work, 'scripts'), { recursive: true })
+  cpSync(
+    resolve(repo, 'scripts/prerender-excel-to-app.mjs'),
+    resolve(work, 'scripts/prerender-excel-to-app.mjs'),
+  )
+  cpSync(
+    resolve(repo, 'scripts/prerender-landing.mjs'),
+    resolve(work, 'scripts/prerender-landing.mjs'),
+  )
+  writeFileSync(resolve(work, 'dist/index.html'), indexHtml)
+
+  execFileSync('node', ['scripts/prerender-excel-to-app.mjs'], { cwd: work })
+
+  const out = readFileSync(resolve(work, 'dist/excel-to-app.html'), 'utf8')
+  assert.match(out, /"@type":"BreadcrumbList"/)
+  assert.match(out, /"name":"Из Excel — приложение"/)
+})


### PR DESCRIPTION
## Что это

Хлебные крошки на всех продуктовых и use-case лендингах — пункт из [issue #477](https://github.com/ideav/backlogram/issues/477) («добавить хлебные крошки на все страницы»).

**Видимая цепочка** «Интеграм / … / текущая страница» — новый общий компонент `src/components/Breadcrumbs.tsx`. Заменяет разрозненные ad-hoc back-link'и (`← На главную`, `← К базе знаний` и т.п.) на единый паттерн. Появляется на:

- `excel-to-app.html`, `agent-platforms.html`, `catalog-matching.html`, `konstruktor-prilozhenij.html`, `informatsionnaya-sistema.html`, `sravnenie-s-bitrix-amocrm.html`, `tokens.html`
- хаб `resheniya.html` и все **11** use-case лендингов (генерятся из `usecases.mjs`, включая новый `dvizhenie-tmc-i-ds` из #478)

**Структурированные данные** `BreadcrumbList` (JSON-LD) добавлены в пререндер-снапшоты этих страниц — там же, где остальной `@graph`, — чтобы breadcrumb-разметку видели и краулеры **без JS (Яндекс)**. Дублей нет: видимая цепочка идёт из React, структура — из статического снапшота. Это и есть SEO-выигрыш (breadcrumb rich snippet в выдаче).

Цепочки:
- `Интеграм / Из Excel — приложение`
- `Интеграм / Из Excel — приложение / ИИ-агент собирает приложение`
- `Интеграм / CRM-учёт клиентов / Сравнение с Битрикс24 и amoCRM`
- `Интеграм / Решения / <название решения>` — для всех use-case (напр. `Интеграм / Решения / Движение ТМЦ и ДС`)
- и т.д.

KB-страницы уже имели `BreadcrumbList` — их не трогал.

## Про #478 («Движение ТМЦ и ДС»)

Ветка сделана поверх #478 (уже смёржен в `main`). Новая страница-решение получает крошки автоматически — код generic по `USE_CASES`. Тривиальный конфликт импорта в `UseCaseLanding.tsx` (там добавили `ArrowLeftRight`, здесь убран `ArrowLeft`) git разрешил при ребейзе сам. Diff PR против `main` — ровно эти крошки, ничего лишнего.

## Проверка

- `npm run build` — зелёный, все 11 лендингов + хаб + standalone-страницы пререндерятся, каждая несёт `"@type":"BreadcrumbList"` в готовом HTML (проверено grep'ом по `dist/`).
- `npm test` — без новых фейлов относительно `main` (обновлён тест `issue-408`, где back-link заменён крошками; добавлен `issue-477-landing-breadcrumbs`).
- Визуально проверил рендер (Playwright по `vite preview`): цепочки корректны на центрированных (`excel-to-app`) и лево-выровненных (`dvizhenie-tmc-i-ds`) hero; ссылки ведут куда надо, текущая страница — `aria-current="page"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
