### PR TITLE
feat(#483): перелинковка блога ↔ продуктовых страниц ideav.ru

### DIFF
--- a/blog-v2/src/components/Footer.astro
+++ b/blog-v2/src/components/Footer.astro
@@ -42,6 +42,8 @@ const year = new Date().getFullYear()
       <h3 class="text-base">Продукт</h3>
       <ul>
         <li><a class="link-swipe" href="https://ideav.ru">ideav.ru</a></li>
+        <li><a class="link-swipe" href="https://ideav.ru/excel-to-app.html">Excel → приложение</a></li>
+        <li><a class="link-swipe" href="https://ideav.ru/konstruktor-prilozhenij.html">Конструктор приложений</a></li>
         <li><a class="link-swipe" href="https://integram.io">integram.io</a></li>
         <li><a class="link-swipe" href="mailto:hello@ideav.ru">hello@ideav.ru</a></li>
       </ul>

--- a/blog-v2/src/pages/posts/[...slug].astro
+++ b/blog-v2/src/pages/posts/[...slug].astro
@@ -183,6 +183,32 @@ const initial = post.data.author.charAt(0)
           </div>
         </div>
 
+        <!-- CTA «Попробуйте Интеграм» — перелинковка блога на продукт (issue #483) -->
+        <aside class="mt-12 rounded-2xl border border-[var(--color-hairline-strong)] bg-[var(--color-product-panel)] p-8 sm:p-10">
+          <div class="eyebrow text-[var(--color-vermilion)] mb-3">Попробуйте Интеграм</div>
+          <h2
+            class="font-[family-name:var(--font-serif)] text-2xl sm:text-[1.9rem] leading-[1.1] tracking-[-0.02em] text-[var(--color-ink)]"
+            style="font-weight: 700;"
+          >
+            От таблицы к рабочему приложению — по описанию задачи
+          </h2>
+          <p class="mt-3 max-w-2xl text-[var(--color-ink-soft)] leading-relaxed">
+            Интеграм собирает приложение с базой данных, ролями и отчётами вместо Excel — без программистов.
+            Пришлите свою таблицу или соберите структуру в конструкторе.
+          </p>
+          <div class="mt-6 flex flex-wrap gap-3">
+            <a href="https://ideav.ru/excel-to-app.html" class="product-button">
+              Excel&nbsp;→&nbsp;приложение за ~45 минут
+            </a>
+            <a
+              href="https://ideav.ru/konstruktor-prilozhenij.html"
+              class="inline-flex items-center justify-center min-h-[2.65rem] px-4 rounded-lg border border-[var(--color-hairline-strong)] font-extrabold text-[var(--color-ink)] hover:border-[var(--color-vermilion)] hover:text-[var(--color-vermilion)] transition-colors"
+            >
+              Конструктор приложений
+            </a>
+          </div>
+        </aside>
+
         <!-- Next issue — keep reading in sequence -->
         {next && (
           <a

--- a/scripts/prerender-agent-platforms.mjs
+++ b/scripts/prerender-agent-platforms.mjs
@@ -179,6 +179,12 @@ const bodyHtml = `
       <a href="/">На главную</a> ·
       <a href="/knowledge-base">База знаний</a>
     </p>
+    <p style="margin-top:0.6rem">
+      Читайте в блоге:
+      <a href="https://blog.ideav.ru/posts/chto-umeet-ii-agent-pri-sborke-prilozheniya/">Что умеет ИИ-агент при сборке приложения</a> ·
+      <a href="https://blog.ideav.ru/posts/ii-chat-vnutri-bazy-agent-dorabatyvaet-prilozhenie/">ИИ-чат внутри приложения: доработки изнутри</a> ·
+      <a href="https://blog.ideav.ru/posts/programmisty-korobka-ili-ii-agent-kto-proektiruet-prilozhenie/">Программисты, коробка или ИИ-агент</a>
+    </p>
   </footer>
 </article>
 <style>

--- a/scripts/prerender-catalog-matching.mjs
+++ b/scripts/prerender-catalog-matching.mjs
@@ -129,6 +129,11 @@ const bodyHtml = `
       <a href="/">На главную</a> ·
       <a href="/knowledge-base/21-catalog-matching.html">База знаний: сопоставление каталогов</a>
     </p>
+    <p style="margin-top:0.6rem">
+      Читайте в блоге:
+      <a href="https://blog.ideav.ru/posts/massovoe-sopostavlenie-katalogov/">Массовое сопоставление каталогов: автоподбор пар</a> ·
+      <a href="https://blog.ideav.ru/posts/sopostavlenie-katalogov-produkcii-v-integram/">Сопоставление каталогов продукции в Интеграме</a>
+    </p>
   </footer>
 </article>
 <style>

--- a/scripts/prerender-excel-to-app.mjs
+++ b/scripts/prerender-excel-to-app.mjs
@@ -132,6 +132,12 @@ const bodyHtml = `
       <a href="/">На главную</a> ·
       <a href="/knowledge-base">База знаний</a>
     </p>
+    <p style="margin-top:0.6rem">
+      Читайте в блоге:
+      <a href="https://blog.ideav.ru/posts/excel-v-prilozhenie-za-45-minut-kak-rabotaet-ii-agent-integrama/">Excel в приложение за 45 минут</a> ·
+      <a href="https://blog.ideav.ru/posts/keis-pekarnya-zamenila-5-excel-na-sistemu-ucheta-zakazov/">Кейс: пекарня заменила 5 Excel на систему учёта</a> ·
+      <a href="https://blog.ideav.ru/posts/keis-logistika-dispetcher-otgruzok-iz-excel-za-den/">Кейс: диспетчер отгрузок из Excel за день</a>
+    </p>
   </footer>
 </article>
 <style>

--- a/scripts/prerender-information-system.mjs
+++ b/scripts/prerender-information-system.mjs
@@ -199,6 +199,12 @@ const bodyHtml = `
       <a href="/">На главную</a> ·
       <a href="/knowledge-base">База знаний</a>
     </p>
+    <p style="margin-top:0.6rem">
+      Читайте в блоге:
+      <a href="https://blog.ideav.ru/posts/edinaya-baza-dannyh-dlya-filialov/">Единая база данных для филиалов</a> ·
+      <a href="https://blog.ideav.ru/posts/bezopasnost-i-otkazoustoichivost-dlya-krupnogo-biznesa/">Безопасность и отказоустойчивость для крупного бизнеса</a> ·
+      <a href="https://blog.ideav.ru/posts/integram-on-premise-lokalno/">Интеграм on-premise: установка в контуре заказчика</a>
+    </p>
   </footer>
 </article>
 <style>

--- a/scripts/prerender-konstruktor-prilozhenij.mjs
+++ b/scripts/prerender-konstruktor-prilozhenij.mjs
@@ -157,6 +157,12 @@ const bodyHtml = `
       <a href="/excel-to-app.html">Загрузить Excel — получить приложение</a> ·
       <a href="/catalog-matching.html">Сопоставление каталогов</a>
     </p>
+    <p style="margin-top:0.6rem">
+      Читайте в блоге:
+      <a href="https://blog.ideav.ru/posts/pervyi-rossiiskii-analog-airtable/">Первый российский аналог Airtable</a> ·
+      <a href="https://blog.ideav.ru/posts/predposylki-no-code-konstruktora-integram/">Предпосылки no-code конструктора Интеграм</a> ·
+      <a href="https://blog.ideav.ru/posts/chto-umeet-ii-agent-pri-sborke-prilozheniya/">Что умеет ИИ-агент при сборке приложения</a>
+    </p>
   </footer>
 </article>
 <style>

--- a/scripts/prerender-sravnenie.mjs
+++ b/scripts/prerender-sravnenie.mjs
@@ -153,6 +153,11 @@ const bodyHtml = `
       <a href="/resheniya.html">Все решения вместо Excel</a> ·
       <a href="/">На главную</a>
     </p>
+    <p style="margin-top:0.6rem">
+      Читайте в блоге:
+      <a href="https://blog.ideav.ru/posts/bitrix24-ai-vibecode-i-sistemnaya-prostota/">Битрикс24 прикручивает AI к сложности</a> ·
+      <a href="https://blog.ideav.ru/posts/crm-sistema-dlya-srednego-biznesa/">CRM-система для среднего бизнеса</a>
+    </p>
   </footer>
 </article>
 <style>

--- a/src/components/BlogLinks.tsx
+++ b/src/components/BlogLinks.tsx
@@ -1,0 +1,64 @@
+import { BookOpen, ArrowUpRight } from 'lucide-react'
+
+// Перелинковка продуктовых страниц ideav.ru на релевантные статьи блога
+// blog.ideav.ru (issue #483) — передаёт ссылочный вес на поддомен блога.
+export interface BlogPostLink {
+  /** Заголовок статьи (человекочитаемый). */
+  title: string
+  /** Слаг поста = имя файла в blog-v2/src/content/posts без .md. */
+  slug: string
+}
+
+const BLOG_BASE = 'https://blog.ideav.ru/posts/'
+
+export default function BlogLinks({
+  posts,
+  title = 'Читайте в блоге',
+  subtitle = 'Разборы, кейсы и практика по теме — в блоге Интеграма',
+}: {
+  posts: BlogPostLink[]
+  title?: string
+  subtitle?: string
+}) {
+  if (!posts.length) return null
+  return (
+    <section className="py-16 border-t border-slate-200 dark:border-slate-900">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-wrap items-end justify-between gap-3 mb-8">
+          <div>
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-blue-500/30 text-blue-600 dark:text-blue-400 text-sm font-medium mb-3">
+              <BookOpen size={14} /> Блог Интеграм
+            </div>
+            <h2 className="text-2xl md:text-3xl font-bold">{title}</h2>
+            <p className="text-slate-500 dark:text-slate-400 mt-2">{subtitle}</p>
+          </div>
+          <a
+            href="https://blog.ideav.ru/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:gap-2 transition-all"
+          >
+            Все статьи <ArrowUpRight size={15} />
+          </a>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {posts.map((p) => (
+            <a
+              key={p.slug}
+              href={`${BLOG_BASE}${p.slug}/`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group p-5 rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 hover:border-blue-500/40 hover:shadow-sm transition-all flex flex-col"
+            >
+              <BookOpen size={18} className="text-blue-500 mb-3" />
+              <span className="text-slate-700 dark:text-slate-200 font-semibold leading-snug flex-1">{p.title}</span>
+              <span className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400">
+                Читать <ArrowUpRight size={14} className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform" />
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/AgentPlatforms.tsx
+++ b/src/pages/AgentPlatforms.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import BlogLinks from '../components/BlogLinks'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
@@ -604,6 +605,14 @@ export default function AgentPlatforms() {
           </p>
         </div>
       </section>
+
+      <BlogLinks
+        posts={[
+          { title: 'Что умеет ИИ-агент Интеграма, когда собирает приложение', slug: 'chto-umeet-ii-agent-pri-sborke-prilozheniya' },
+          { title: 'ИИ-чат внутри приложения: агент дорабатывает базу изнутри', slug: 'ii-chat-vnutri-bazy-agent-dorabatyvaet-prilozhenie' },
+          { title: 'Программисты, коробка или ИИ-агент: кто проектирует ваше приложение', slug: 'programmisty-korobka-ili-ii-agent-kto-proektiruet-prilozhenie' },
+        ]}
+      />
     </div>
   )
 }

--- a/src/pages/BitrixAmoComparison.tsx
+++ b/src/pages/BitrixAmoComparison.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import BlogLinks from '../components/BlogLinks'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
@@ -426,6 +427,13 @@ export default function BitrixAmoComparison() {
           </p>
         </div>
       </section>
+
+      <BlogLinks
+        posts={[
+          { title: 'Битрикс24 прикручивает AI к сложности. Почему Интеграм идёт другим путём', slug: 'bitrix24-ai-vibecode-i-sistemnaya-prostota' },
+          { title: 'CRM-система для среднего бизнеса: разбор кейса', slug: 'crm-sistema-dlya-srednego-biznesa' },
+        ]}
+      />
     </div>
   )
 }

--- a/src/pages/CatalogMatching.tsx
+++ b/src/pages/CatalogMatching.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import BlogLinks from '../components/BlogLinks'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
@@ -836,22 +837,19 @@ export default function CatalogMatching() {
           </div>
 
           <p className="mt-10 text-center text-sm">
-            <a
-              href="https://blog.ideav.ru/posts/massovoe-sopostavlenie-katalogov/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors"
-            >
-              Подробный разбор в блоге: массовый автоподбор пар →
-            </a>
-          </p>
-          <p className="mt-2 text-center text-sm">
             <Link to="/knowledge-base/21-catalog-matching.html" className="text-slate-400 dark:text-slate-500 hover:text-blue-500 transition-colors">
               В базе знаний: Интеграм вместо Elasticsearch →
             </Link>
           </p>
         </div>
       </section>
+
+      <BlogLinks
+        posts={[
+          { title: 'Массовое сопоставление каталогов в Интеграме: автоматический подбор пар', slug: 'massovoe-sopostavlenie-katalogov' },
+          { title: 'Сопоставление каталогов продукции в конструкторе Интеграм', slug: 'sopostavlenie-katalogov-produkcii-v-integram' },
+        ]}
+      />
     </div>
   )
 }

--- a/src/pages/ExcelConstructor.tsx
+++ b/src/pages/ExcelConstructor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import BlogLinks from '../components/BlogLinks'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
@@ -787,6 +788,14 @@ export default function ExcelConstructor() {
           </p>
         </div>
       </section>
+
+      <BlogLinks
+        posts={[
+          { title: 'Первый российский аналог Airtable', slug: 'pervyi-rossiiskii-analog-airtable' },
+          { title: 'Предпосылки no-code конструктора Интеграм', slug: 'predposylki-no-code-konstruktora-integram' },
+          { title: 'Что умеет ИИ-агент Интеграма, когда собирает приложение', slug: 'chto-umeet-ii-agent-pri-sborke-prilozheniya' },
+        ]}
+      />
     </div>
   )
 }

--- a/src/pages/ExcelToApp.tsx
+++ b/src/pages/ExcelToApp.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import BlogLinks from '../components/BlogLinks'
 import { motion } from 'framer-motion'
 import { reachGoal } from '../lib/metrika'
 import {
@@ -1030,6 +1031,14 @@ export default function ExcelToApp() {
           </div>
         </div>
       </section>
+
+      <BlogLinks
+        posts={[
+          { title: 'Excel в приложение за 45 минут: чем отличается подход Интеграма', slug: 'excel-v-prilozhenie-za-45-minut-kak-rabotaet-ii-agent-integrama' },
+          { title: 'Пекарня заменила 5 Excel-файлов на одну систему учёта заказов', slug: 'keis-pekarnya-zamenila-5-excel-na-sistemu-ucheta-zakazov' },
+          { title: 'Как логистическая компания за день сделала диспетчера отгрузок из Excel', slug: 'keis-logistika-dispetcher-otgruzok-iz-excel-za-den' },
+        ]}
+      />
     </div>
   )
 }

--- a/src/pages/InformationSystem.tsx
+++ b/src/pages/InformationSystem.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import BlogLinks from '../components/BlogLinks'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
@@ -639,6 +640,14 @@ export default function InformationSystem() {
           </p>
         </div>
       </section>
+
+      <BlogLinks
+        posts={[
+          { title: 'Единая база данных для филиалов', slug: 'edinaya-baza-dannyh-dlya-filialov' },
+          { title: 'Безопасность и отказоустойчивость Интеграма для крупного бизнеса', slug: 'bezopasnost-i-otkazoustoichivost-dlya-krupnogo-biznesa' },
+          { title: 'Интеграм on-premise: установка в контуре заказчика', slug: 'integram-on-premise-lokalno' },
+        ]}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Closes #483.

Перелинковка `blog.ideav.ru` ↔ `ideav.ru` реальными ссылками — sitemap сам по себе ссылочный вес не передаёт. Реализованы все три пункта задачи.

## 1. Блок «Попробуйте Интеграм» в каждой статье блога

Добавлен в шаблон статьи `blog-v2/src/pages/posts/[...slug].astro` (после концовки статьи, перед «следующим выпуском») — значит, появляется во **всех 72 статьях** сразу. Ссылки на `ideav.ru/excel-to-app.html` (основная кнопка) и `ideav.ru/konstruktor-prilozhenij.html`. Стилизован под дизайн блога (serif-заголовок, `--color-vermilion`, `.product-button`).

## 2. Футер блога → продуктовые страницы

Раздел «Продукт» в `blog-v2/src/components/Footer.astro` дополнен ссылками на `excel-to-app.html` и `konstruktor-prilozhenij.html` (раньше был только голый `ideav.ru`) — целевой вес идёт на «денежные» страницы.

## 3. Блок «Читайте в блоге» на продуктовых страницах ideav.ru

Новый компонент `src/components/BlogLinks.tsx` — секция с карточками релевантных статей. Добавлен на 6 продуктовых страниц:

| Страница | Статьи |
|---|---|
| excel-to-app | Excel→app за 45 мин · пекарня · логистика |
| konstruktor-prilozhenij | аналог Airtable · предпосылки no-code · ИИ-агент |
| catalog-matching | массовое сопоставление · сопоставление каталогов |
| informatsionnaya-sistema | база для филиалов · безопасность · on-premise |
| agent-platforms | ИИ-агент · ИИ-чат · программисты/коробка/агент |
| sravnenie-s-bitrix-amocrm | Битрикс24-AI · CRM-кейс |

**Важно для SEO:** продуктовые страницы — это SPA с рукописными пререндер-снапшотами (краулеры видят статику, не React). Поэтому те же ссылки добавлены и в футеры пререндер-снапшотов (`scripts/prerender-*.mjs`) — **16 crawlable-ссылок** передают вес даже без исполнения JS. Компонент `BlogLinks` при этом даёт живой визуальный блок пользователю.

В `CatalogMatching` убрана старая одиночная сноска на блог (та же статья теперь в новом блоке).

## Проверка

- Все 15 использованных слагов существуют в `blog-v2/src/content/posts`.
- `npm run build` (React, 11 лендингов + хаб, verify-htaccess ✓) и `blog-v2 && npm run build` (Astro, 72 страницы) — зелёные.
- Отрисовку блока-CTA в статье и «Читайте в блоге» на `/excel-to-app.html` проверил в браузере; статические ссылки в пререндер-снапшотах — grep’ом (по 2-3 на страницу).
- Изменения наложены на свежий `origin/main` — правки чужих PR (#473/#474 рерайт сравнения, #477 хлебные крошки) сохранены, не затёрты.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
