### PR TITLE
fix(#502): 301 с легаси-URL старого блога вместо 404 на blog.ideav.ru

### DIFF
--- a/blog-v2/public/.htaccess
+++ b/blog-v2/public/.htaccess
@@ -7,3 +7,37 @@
 # .htaccess просто игнорируется (не ошибка) — блог продолжает работать, а
 # /sitemap.xml остаётся 404; тогда правило нужно перенести в конфиг vhost.
 RedirectMatch 301 ^/sitemap\.xml$ https://blog.ideav.ru/sitemap-index.xml
+
+# === Легаси-URL старого блога, попавшие в обход уже на blog.ideav.ru =========
+# issue #502. Яндекс.Вебмастер держит в «Исключённых» адреса в формате HTMLy
+# (/YYYY/MM/<slug>, /archive/<...>) — но на ЭТОМ домене, а не на
+# blog.ideav.online: они попали в обход, пока шёл переезд (#373), и отдают 404,
+# так что накопленный ссылочный вес теряется. На стороне старого блога карта
+# уже стоит (old-blog-redirect/), здесь — её зеркало для новых адресов.
+#
+# Порядок важен: сперва точное попадание в существующий пост, и только если
+# такого поста нет — фолбэк на главную. Ни один 301 не ведёт в 404.
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+
+  # 1. Датированный пермалинк HTMLy -> /posts/<slug>/, если такой пост есть.
+  #    Astro собран с build.format: 'directory', поэтому пост на диске — это
+  #    /posts/<slug>/index.html. $1 в RewriteCond — группа из RewriteRule ниже.
+  RewriteCond %{DOCUMENT_ROOT}/posts/$1/index.html -f
+  RewriteRule ^[0-9]{4}/[0-9]{2}/([^/]+)/?$ /posts/$1/ [R=301,L,QSD]
+
+  # 2. Недатированный пермалинк HTMLy (/post/<slug>) — та же логика.
+  RewriteCond %{DOCUMENT_ROOT}/posts/$1/index.html -f
+  RewriteRule ^post/([^/]+)/?$ /posts/$1/ [R=301,L,QSD]
+
+  # 3. Фиды HTMLy -> RSS нового блога.
+  RewriteRule ^feed(/(rss|opml))?/?$ /rss.xml [R=301,L,QSD]
+
+  # 4. Остальное наследие HTMLy (архивы, авторы, типы, удалённые посты) ->
+  #    главная. Сюда же падают датированные URL, для которых поста уже нет.
+  #    Ничего, кроме этих префиксов, не трогаем: собственные 404 нового блога
+  #    должны оставаться 404, а /search — живая страница blog-v2.
+  RewriteRule ^[0-9]{4}/[0-9]{2}(/|$) / [R=301,L,QSD]
+  RewriteRule ^(archive|author|type|post)(/|$) / [R=301,L,QSD]
+</IfModule>

--- a/tests/issue-502-blog-legacy-redirects.test.mjs
+++ b/tests/issue-502-blog-legacy-redirects.test.mjs
@@ -1,0 +1,149 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const POSTS_DIR = join(__dirname, '..', 'blog-v2', 'src', 'content', 'posts')
+const HTACCESS = join(__dirname, '..', 'blog-v2', 'public', '.htaccess')
+
+/**
+ * Regression coverage for https://github.com/ideav/backlogram/issues/502
+ *
+ * Яндекс.Вебмастер держит в «Исключённых» страницы blog.ideav.ru, и часть из
+ * них — легаси-адреса старого HTMLy-блога (/YYYY/MM/<slug>, /archive/<...>),
+ * попавшие в обход уже на новом домене и отдающие 404. `old-blog-redirect/`
+ * закрывает эту карту на стороне blog.ideav.online, а `blog-v2/public/.htaccess`
+ * — её зеркало на самом blog.ideav.ru.
+ *
+ * Инварианты, которые сторожит тест:
+ *  - легаси-URL поста ведёт на существующий /posts/<slug>/ (никаких 301 -> 404);
+ *  - легаси-URL без поста и архивы уходят на главную, а не в 404;
+ *  - живые маршруты нового блога (/posts/, /tag/, /category/, /search,
+ *    /rss.xml, статика) правилами не задеты;
+ *  - правило /sitemap.xml -> /sitemap-index.xml из #480 никуда не делось.
+ */
+
+const htaccess = readFileSync(HTACCESS, 'utf8')
+const postSlugs = new Set(
+  readdirSync(POSTS_DIR)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => f.replace(/\.md$/, '')),
+)
+
+/**
+ * Order-faithful simulator of blog-v2/public/.htaccess.
+ * `RewriteCond %{DOCUMENT_ROOT}/posts/$1/index.html -f` моделируется набором
+ * слагов из контент-коллекции: Astro собран с build.format 'directory', так что
+ * каждый пост на диске — это /posts/<slug>/index.html.
+ * Возвращает целевой путь или null, если запрос отдаётся как есть.
+ */
+function redirect(url) {
+  const p = url.replace(/^\/+/, '').split('?')[0]
+
+  if (/^sitemap\.xml$/.test(p)) return '/sitemap-index.xml'
+
+  let m
+  if ((m = p.match(/^[0-9]{4}\/[0-9]{2}\/([^/]+)\/?$/)) && postSlugs.has(m[1]))
+    return `/posts/${m[1]}/`
+  if ((m = p.match(/^post\/([^/]+)\/?$/)) && postSlugs.has(m[1]))
+    return `/posts/${m[1]}/`
+  if (/^feed(\/(rss|opml))?\/?$/.test(p)) return '/rss.xml'
+  if (/^[0-9]{4}\/[0-9]{2}(\/|$)/.test(p)) return '/'
+  if (/^(archive|author|type|post)(\/|$)/.test(p)) return '/'
+
+  return null // ничего не совпало — отдаём как есть (или честный 404 Astro)
+}
+
+test('.htaccess существует и содержит оба блока правил', () => {
+  assert.ok(existsSync(HTACCESS), 'blog-v2/public/.htaccess must exist')
+  // #480 — не потерять при правках.
+  assert.match(
+    htaccess,
+    /RedirectMatch 301 \^\/sitemap\\\.xml\$ https:\/\/blog\.ideav\.ru\/sitemap-index\.xml/,
+  )
+  // #502 — датированный пермалинк проверяется на существование поста.
+  assert.match(
+    htaccess,
+    /RewriteCond %\{DOCUMENT_ROOT\}\/posts\/\$1\/index\.html -f/,
+  )
+  assert.match(
+    htaccess,
+    /RewriteRule \^\[0-9\]\{4\}\/\[0-9\]\{2\}\/\(\[\^\/\]\+\)\/\?\$ \/posts\/\$1\/ \[R=301/,
+  )
+  // Фолбэк на главную для легаси без поста.
+  assert.match(
+    htaccess,
+    /RewriteRule \^\(archive\|author\|type\|post\)\(\/\|\$\) \/ \[R=301/,
+  )
+})
+
+test('404-адреса из выгрузки Вебмастера (#502) больше не 404', () => {
+  const cases = [
+    ['/2024/03/crm-sistema-dlya-srednego-biznesa', '/posts/crm-sistema-dlya-srednego-biznesa/'],
+    ['/2024/04/pravilo-6-tehnicheskoe-zadanie', '/posts/pravilo-6-tehnicheskoe-zadanie/'],
+    [
+      '/2023/12/keis-sistema-dlya-obzvona-spyashih-klientov-za-1-chas',
+      '/posts/keis-sistema-dlya-obzvona-spyashih-klientov-za-1-chas/',
+    ],
+    ['/archive/2024-07', '/'],
+  ]
+  for (const [url, expected] of cases) {
+    assert.equal(redirect(url), expected, `${url} should -> ${expected}`)
+  }
+})
+
+test('ни один 301 не ведёт в 404: цель поста всегда существует', () => {
+  const offenders = []
+  for (const slug of postSlugs) {
+    const target = redirect(`/2024/03/${slug}`)
+    if (target !== `/posts/${slug}/`) offenders.push(`${slug} -> ${target}`)
+  }
+  assert.equal(offenders.length, 0, offenders.join('\n'))
+
+  // Удалённый/переименованный пост не превращается в 301 -> 404.
+  assert.equal(redirect('/2024/03/etogo-posta-bolshe-net'), '/')
+  assert.equal(redirect('/post/etogo-posta-bolshe-net'), '/')
+})
+
+test('легаси-пермалинки HTMLy и фиды перекрыты', () => {
+  const [anySlug] = postSlugs
+  assert.equal(redirect(`/post/${anySlug}`), `/posts/${anySlug}/`)
+  assert.equal(redirect(`/post/${anySlug}/`), `/posts/${anySlug}/`)
+  assert.equal(redirect('/feed'), '/rss.xml')
+  assert.equal(redirect('/feed/rss'), '/rss.xml')
+  assert.equal(redirect('/feed/opml'), '/rss.xml')
+  assert.equal(redirect('/2024/07'), '/')
+  assert.equal(redirect('/archive'), '/')
+})
+
+test('живые маршруты нового блога правилами не задеты', () => {
+  const [anySlug] = postSlugs
+  for (const url of [
+    '/',
+    `/posts/${anySlug}/`,
+    '/tag/integram/',
+    '/category/razrabotka/',
+    '/search',
+    '/rss.xml',
+    '/llms.txt',
+    '/robots.txt',
+    '/sitemap-index.xml',
+    '/sitemap-0.xml',
+    '/uploads/2024/03/pic.jpg',
+    '/_astro/index.css',
+    '/pagefind/pagefind.js',
+  ]) {
+    assert.equal(redirect(url), null, `${url} must be served, not redirected`)
+  }
+})
+
+test('query-строка не мешает совпадению правил', () => {
+  assert.equal(
+    redirect('/2024/03/crm-sistema-dlya-srednego-biznesa?utm_source=yandex'),
+    '/posts/crm-sistema-dlya-srednego-biznesa/',
+  )
+  // QSD в правилах отбрасывает старую query — цель без хвоста.
+  assert.match(htaccess, /\[R=301,L,QSD\]/)
+})


### PR DESCRIPTION
Разбор выгрузки «Исключённые страницы» из Яндекс.Вебмастера по `blog.ideav.ru` из [issue #502](https://github.com/ideav/backlogram/issues/502) — 31 адрес. Реально чинить нужно было только 4 из них; остальные разобраны ниже, там всё в порядке.

## Что в выгрузке (31 URL)

| Статус | Сколько | Что это |
|---|---|---|
| `HTTP_ERROR` (404) | 4 | **настоящая проблема** — легаси-URL старого HTMLy-блога, но уже на `blog.ideav.ru` |
| `REDIRECT_NOTSEARCHABLE` (301) | 12 | `/tag/x` и `/category/x` без слеша → `/tag/x/`. Штатное поведение Apache `DirectorySlash`, целевые страницы отвечают 200 и лежат в sitemap |
| `LOW_DEMAND` (200) | 14 | оценка Яндекса «малоспрашиваемая страница». Технических блокеров нет |
| `BAD_MIME_TYPE` (200) | 1 | `/rss.xml` — фид, не HTML-страница; в индексе ему и не место |

## Что исправлено

Четыре 404 — это адреса в формате старого блога, попавшие в обход **на новом домене** во время переезда (#373):

```
/2024/03/crm-sistema-dlya-srednego-biznesa
/2024/04/pravilo-6-tehnicheskoe-zadanie
/2023/12/keis-sistema-dlya-obzvona-spyashih-klientov-za-1-chas
/archive/2024-07
```

Карта `old-blog-redirect/` закрывала такие URL только на стороне `blog.ideav.online` (там всё работает — проверил живьём, 301 уходит верно). На самом `blog.ideav.ru` их никто не ловил. Зеркалим карту в `blog-v2/public/.htaccess` — файл едет в `dist/` при сборке (проверено):

- `/YYYY/MM/<slug>` и `/post/<slug>` → `/posts/<slug>/`, **но только если такой пост есть**: `RewriteCond %{DOCUMENT_ROOT}/posts/$1/index.html -f` (Astro собран с `build.format: 'directory'`);
- `/feed`, `/feed/rss`, `/feed/opml` → `/rss.xml`;
- остальное наследие HTMLy (`/archive`, `/author`, `/type`, `/post`, датированные URL без поста) → главная.

Ни один 301 не ведёт в 404, живые маршруты (`/posts/`, `/tag/`, `/category/`, `/search`, `/rss.xml`, статика) не затронуты, а честные 404 нового блога остаются 404. Правило `/sitemap.xml` → `/sitemap-index.xml` из #480 на месте.

## Проверка

Собрал `blog-v2` и поднял **реальный Apache 2.4** (`docker httpd:2.4-alpine`, `AllowOverride All`) поверх `dist/`:

```
/2024/03/crm-sistema-dlya-srednego-biznesa       hops=1 final=200 → /posts/crm-sistema-dlya-srednego-biznesa/
/2024/04/pravilo-6-tehnicheskoe-zadanie          hops=1 final=200 → /posts/pravilo-6-tehnicheskoe-zadanie/
/2023/12/keis-sistema-dlya-obzvona-...-za-1-chas hops=1 final=200 → /posts/keis-sistema-dlya-obzvona-.../
/archive/2024-07                                 hops=1 final=200 → /
/2024/03/etogo-posta-net                         301 → /            (не 301 → 404)
/post/crm-sistema-dlya-srednego-biznesa          301 → /posts/crm-sistema-dlya-srednego-biznesa/
/posts/nesushestvuyushii-post/                   404               (честный 404 остался 404)
/ /posts/… /tag/integram/ /category/razrabotka/ /search/ /rss.xml /sitemap-index.xml  → 200
```

Плюс регрессионный тест `tests/issue-502-blog-legacy-redirects.test.mjs` (6 кейсов, проходят) — симулятор правил в порядке их следования, как в `tests/old-blog-redirect.test.mjs`.

## Что осталось сделать руками (вне репозитория)

1. Задеплоить `blog-v2/dist/` на `blog.ideav.ru` — без выкладки правила не заработают.
2. В Вебмастере: **Индексирование → Переобход страниц** — отправить 4 адреса выше, чтобы Яндекс увидел 301.
3. `LOW_DEMAND` и `REDIRECT_NOTSEARCHABLE` руками не «возвращаются»: первый снимается только спросом/качеством, второй — вообще не потеря (в индексе живёт вариант со слешем).

## Замечания, которые чинить не стал

- `tests/old-blog-redirect.test.mjs` падает **на main** до этого PR: у блога появились теги `planirovanie`, `testirovanie`, `processy`, `lichnye-finansy`, которых нет в карте `old-blog-redirect/.htaccess`. На вес это не влияет (на старом блоге этих тегов не было), но инвариант стоит либо починить, либо ослабить — отдельной задачей.
- `/rss.xml` (`BAD_MIME_TYPE`) намеренно не трогал: `application/rss+xml` не вернёт фид в индекс (фиды туда и не берут), зато часть браузеров начнёт скачивать его файлом вместо показа.
- `/tag/airtable/` в `LOW_DEMAND` — тег с одной статьёй и ~200 словами. Если таких тегов накопится много, разумно перестать индексировать теги с единственным материалом — тоже отдельной задачей.

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6vqpa4Jq5ZpHd2PCMkbiP