### PR TITLE
feat(#512): слайдер статей блога на главной с кнопкой «Перейти в блог»

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "scripts": {
     "dev": "vite",
     "test": "node --test tests/*.test.mjs",
-    "build": "node scripts/generate-og-images.mjs && node scripts/sync-kb-sitemap.mjs && vite build && node scripts/prerender-knowledge-base.mjs && node scripts/prerender-excel-to-app.mjs && node scripts/prerender-agent-platforms.mjs && node scripts/prerender-catalog-matching.mjs && node scripts/prerender-information-system.mjs && node scripts/prerender-sravnenie.mjs && node scripts/prerender-konstruktor-prilozhenij.mjs && node scripts/prerender-usecases.mjs && node scripts/prerender-tokens.mjs && node scripts/prerender-landing.mjs && node scripts/verify-htaccess.mjs",
+    "build": "node scripts/generate-blog-posts.mjs && node scripts/generate-og-images.mjs && node scripts/sync-kb-sitemap.mjs && vite build && node scripts/prerender-knowledge-base.mjs && node scripts/prerender-excel-to-app.mjs && node scripts/prerender-agent-platforms.mjs && node scripts/prerender-catalog-matching.mjs && node scripts/prerender-information-system.mjs && node scripts/prerender-sravnenie.mjs && node scripts/prerender-konstruktor-prilozhenij.mjs && node scripts/prerender-usecases.mjs && node scripts/prerender-tokens.mjs && node scripts/prerender-landing.mjs && node scripts/verify-htaccess.mjs",
     "og-images": "node scripts/generate-og-images.mjs",
+    "blog-posts": "node scripts/generate-blog-posts.mjs",
     "blog-figures": "node scripts/render-blog-figures.mjs",
     "kb-sitemap": "node scripts/sync-kb-sitemap.mjs",
     "preview": "vite preview"

--- a/scripts/generate-blog-posts.mjs
+++ b/scripts/generate-blog-posts.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Генерация `src/data/blogPosts.mjs` — свежих статей блога для слайдера на
+ * главной (issue #512).
+ *
+ * Блог (blog.ideav.ru) собирается Astro отдельно от сайта (ideav.ru, React+Vite)
+ * и живёт на другом домене, поэтому список статей нужно «запечь» в данные до
+ * сборки SPA. Скрипт запускается первым шагом `npm run build` и вручную —
+ * `npm run blog-posts` — когда в блог добавили статью.
+ *
+ * Результат коммитится: он нужен и `vite dev`, и пререндеру главной
+ * (`scripts/prerender-landing.mjs`), который читает тот же модуль.
+ */
+import { writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { BLOG_URL, SLIDER_LIMIT, readBlogPosts } from './lib/blog-posts.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const outPath = resolve(__dirname, '..', 'src/data/blogPosts.mjs')
+
+const posts = readBlogPosts(SLIDER_LIMIT)
+if (posts.length === 0) {
+  console.error('✗ generate-blog-posts: в blog-v2/src/content/posts не найдено ни одной статьи')
+  process.exit(1)
+}
+
+/** Значение в одинарных кавычках — как в остальных data-модулях. */
+function quote(value) {
+  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+}
+
+const entries = posts
+  .map(
+    (p) => `  {
+    slug: ${quote(p.slug)},
+    url: ${quote(p.url)},
+    title: ${quote(p.title)},
+    description: ${quote(p.description)},
+    date: ${quote(p.date)},
+    dateLabel: ${quote(p.dateLabel)},
+    category: ${quote(p.category)},
+    image: ${quote(p.image)},
+  },`
+  )
+  .join('\n')
+
+const file = `// Сгенерировано скриптом scripts/generate-blog-posts.mjs — руками не править.
+// Источник: blog-v2/src/content/posts/*.md. Обновить: npm run blog-posts.
+//
+// Свежие статьи блога для слайдера на главной (issue #512). Блог — отдельная
+// Astro-сборка на blog.ideav.ru, поэтому список «запекается» в данные на этапе
+// сборки: файл импортируют и React (src/components/BlogSlider.tsx), и Node-скрипт
+// пререндера главной (scripts/prerender-landing.mjs). Типы — src/data/blogPosts.d.ts.
+
+export const BLOG_URL = ${quote(BLOG_URL)}
+
+export const BLOG_POSTS = [
+${entries}
+]
+`
+
+writeFileSync(outPath, file)
+console.log(`✓ blog posts → src/data/blogPosts.mjs (${posts.length} шт., свежая: ${posts[0].date})`)

--- a/scripts/lib/blog-posts.mjs
+++ b/scripts/lib/blog-posts.mjs
@@ -1,0 +1,143 @@
+/**
+ * Чтение статей блога (`blog-v2/src/content/posts/*.md`) обычным Node —
+ * без Astro и без зависимостей.
+ *
+ * Зачем: главная (ideav.ru) и блог (blog.ideav.ru) — две независимые сборки.
+ * React-приложению неоткуда взять список статей в рантайме, поэтому свежие
+ * материалы «запекаются» в `src/data/blogPosts.mjs` на этапе сборки
+ * (`scripts/generate-blog-posts.mjs`, issue #512). Разбор вынесен сюда, чтобы
+ * тест мог сверить сгенерированный файл с исходным контентом, не запуская
+ * генератор (тот сразу перезаписывает файл).
+ *
+ * YAML-фронтматтер разбирается мини-парсером: в постах встречаются только
+ * скаляры (голые, в одинарных и двойных кавычках) и блочные списки (`tags`).
+ * Свёрнутых блоков (`|`, `>`) и вложенных мэппингов в контенте нет — если
+ * появятся, тест `tests/issue-512-blog-slider.test.mjs` поймает расхождение.
+ */
+import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..', '..')
+
+export const BLOG_URL = 'https://blog.ideav.ru'
+export const POSTS_DIR = resolve(repoRoot, 'blog-v2/src/content/posts')
+const BLOG_PUBLIC = resolve(repoRoot, 'blog-v2/public')
+
+/** Сколько статей уезжает в слайдер на главной. */
+export const SLIDER_LIMIT = 9
+
+const MONTHS = [
+  'января', 'февраля', 'марта', 'апреля', 'мая', 'июня',
+  'июля', 'августа', 'сентября', 'октября', 'ноября', 'декабря',
+]
+
+/** Скаляр YAML: снимает кавычки и разворачивает экранирование. */
+function unquote(raw) {
+  const value = raw.trim()
+  if (value.startsWith("'") && value.endsWith("'") && value.length > 1) {
+    return value.slice(1, -1).replace(/''/g, "'")
+  }
+  if (value.startsWith('"') && value.endsWith('"') && value.length > 1) {
+    return value.slice(1, -1).replace(/\\(["\\])/g, '$1')
+  }
+  return value
+}
+
+/** Фронтматтер поста → плоский объект (значения-списки собираются в массив). */
+export function parseFrontmatter(source) {
+  const block = source.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!block) return null
+
+  const data = {}
+  let listKey = null
+  for (const line of block[1].split(/\r?\n/)) {
+    const item = line.match(/^\s*-\s+(.*)$/)
+    if (item && listKey) {
+      data[listKey].push(unquote(item[1]))
+      continue
+    }
+    const pair = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/)
+    if (!pair) continue
+    const [, key, rest] = pair
+    if (rest.trim() === '') {
+      listKey = key
+      data[key] = []
+    } else {
+      listKey = null
+      data[key] = unquote(rest)
+    }
+  }
+  return data
+}
+
+/** «2026-07-17» → «17 июля 2026». Своя таблица месяцев — не зависим от ICU. */
+export function formatDate(iso) {
+  const [y, m, d] = iso.split('-').map(Number)
+  return `${d} ${MONTHS[m - 1]} ${y}`
+}
+
+/**
+ * Обложка карточки. Повторяет логику блога (`blog-v2/src/pages/index.astro`):
+ * `image:` из фронтматтера → первая картинка из текста → абстрактная заглушка.
+ * Для обложек с готовым OG-вариантом 1200×630 (`/uploads/og/<имя>.jpg`,
+ * см. blog-v2/scripts/generate-og-covers.mjs) берём его: он легче исходного
+ * скриншота и даёт единое соотношение сторон во всех карточках.
+ */
+function coverImage(data, body, index) {
+  const declared = data.image || (body.match(/!\[[^\]]*\]\((\/uploads\/[^)\s]+)\)/) ?? [])[1]
+  if (!declared) return `/abstract/blog-material-${(index % 6) + 1}.svg`
+  if (!declared.startsWith('/uploads/')) return declared
+
+  const stem = declared.slice(declared.lastIndexOf('/') + 1).replace(/\.[^.]+$/, '')
+  const variant = `/uploads/og/${stem}.jpg`
+  return existsSync(resolve(BLOG_PUBLIC, variant.slice(1))) ? variant : declared
+}
+
+/**
+ * Свежие статьи блога, от новой к старой.
+ *
+ * Порядок и фильтр — как на самом блоге: скрываем только `draft: true`
+ * (посты «из будущего» блог тоже показывает), сортируем по `pubDate`, а
+ * совпадающие даты оставляем в алфавитном порядке файлов — сортировка
+ * стабильная, значит слайдер и главная блога идут в одном порядке.
+ */
+export function readBlogPosts(limit = SLIDER_LIMIT) {
+  const files = readdirSync(POSTS_DIR)
+    .filter((name) => name.endsWith('.md'))
+    .sort()
+
+  const posts = []
+  for (const file of files) {
+    const source = readFileSync(resolve(POSTS_DIR, file), 'utf8')
+    const data = parseFrontmatter(source)
+    if (!data) throw new Error(`blog-posts: нет фронтматтера в ${file}`)
+    if (data.draft === 'true') continue
+    if (!data.title || !data.pubDate) throw new Error(`blog-posts: нет title/pubDate в ${file}`)
+
+    posts.push({
+      slug: file.replace(/\.md$/, ''),
+      title: data.title,
+      description: data.description ?? '',
+      date: data.pubDate,
+      category: data.category ?? 'Без категории',
+      image: data.image ?? '',
+      body: source.slice(source.indexOf('\n---', 3) + 4),
+    })
+  }
+
+  return posts
+    .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
+    .slice(0, limit)
+    .map((post, index) => ({
+      slug: post.slug,
+      url: `${BLOG_URL}/posts/${post.slug}/`,
+      title: post.title,
+      description: post.description,
+      date: post.date,
+      dateLabel: formatDate(post.date),
+      category: post.category,
+      image: BLOG_URL + coverImage(post, post.body, index),
+    }))
+}

--- a/scripts/prerender-landing.mjs
+++ b/scripts/prerender-landing.mjs
@@ -20,6 +20,7 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { USE_CASES } from '../src/data/usecases.mjs'
+import { BLOG_URL, BLOG_POSTS } from '../src/data/blogPosts.mjs'
 import { HOME_FAQ } from '../src/data/home-faq.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -98,6 +99,27 @@ const sectionsHtml = sections
 //  ответ совпадал с видимым на странице, поэтому ссылка перелинковки идёт
 //  отдельным абзацем.
 // ───────────────────────────────────────────────────────────────────────────
+// ───────────────────────────────────────────────────────────────────────────
+//  Свежие статьи блога (issue #512). Зеркалит слайдер из src/components/
+//  BlogSlider.tsx: в SPA карточки рисует React, а в статичном снапшоте это
+//  единственный способ показать краулерам и клиентам без JS, что у сайта есть
+//  живой блог, и передать на blog.ideav.ru ссылочный вес с главной.
+// ───────────────────────────────────────────────────────────────────────────
+const blogHtml = `
+      <section class="lp-prerender__group" aria-labelledby="lp-blog-title">
+        <h2 id="lp-blog-title">Свежее в блоге</h2>
+        <p>Разборы проектов, кейсы заказчиков и то, как устроена платформа изнутри.</p>
+        <ul class="lp-prerender__posts">
+          ${BLOG_POSTS.map(
+            (post) => `<li>
+            <a href="${escape(post.url)}">${escape(post.title)}</a>
+            <span class="lp-prerender__post-meta">${escape(post.category)} · <time datetime="${escape(post.date)}">${escape(post.dateLabel)}</time></span>
+          </li>`
+          ).join('\n          ')}
+        </ul>
+        <p><a href="${escape(BLOG_URL)}/">Перейти в блог</a></p>
+      </section>`
+
 const faqHtml = `
       <section class="lp-prerender__group" aria-labelledby="lp-faq-title">
         <h2 id="lp-faq-title">Частые вопросы</h2>
@@ -143,6 +165,7 @@ const bodyHtml = `
     </p>
   </header>
   ${sectionsHtml}
+  ${blogHtml}
   ${faqHtml}
   <footer class="lp-prerender__footer">
     <p class="lp-prerender__seo">${escape(SEO_FOOTER)}</p>
@@ -174,6 +197,9 @@ const bodyHtml = `
   #lp-prerender .lp-prerender__eyebrow { text-transform: uppercase; letter-spacing: 0.1em;
     font-size: 0.72rem; color: #3b82f6; font-weight: 700; margin: 0; }
   #lp-prerender .lp-prerender__lead { font-size: 1.1rem; color: #475569; max-width: 50rem; }
+  #lp-prerender .lp-prerender__posts { margin: 0.75rem 0 0; padding: 0; list-style: none; }
+  #lp-prerender .lp-prerender__posts li { margin: 0.5rem 0; }
+  #lp-prerender .lp-prerender__post-meta { display: block; font-size: 0.85rem; color: #64748b; }
   #lp-prerender .lp-prerender__faq-item { margin: 1rem 0; }
   #lp-prerender .lp-prerender__faq-item h3 { font-size: 1.05rem; margin: 0 0 0.25rem; }
   #lp-prerender .lp-prerender__faq-link { font-size: 0.92rem; }

--- a/src/components/BlogSlider.tsx
+++ b/src/components/BlogSlider.tsx
@@ -1,0 +1,147 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { motion } from 'framer-motion'
+import { ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react'
+import { BLOG_URL, BLOG_POSTS } from '../data/blogPosts'
+
+/**
+ * Слайдер свежих статей блога на главной (issue #512).
+ *
+ * Данные — из src/data/blogPosts.mjs: блог живёт отдельной Astro-сборкой на
+ * blog.ideav.ru, поэтому список статей запекается на этапе сборки скриптом
+ * scripts/generate-blog-posts.mjs. Тот же модуль читает пререндер главной
+ * (scripts/prerender-landing.mjs) — иначе краулеры карточек не увидят.
+ *
+ * Прокрутка — нативная (scroll-snap + свайп на тач-устройствах), стрелки лишь
+ * сдвигают её на карточку и гаснут на краях: своей анимации нет, значит нечему
+ * рассинхронизироваться с реальным положением ленты.
+ */
+export default function BlogSlider() {
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [atStart, setAtStart] = useState(true)
+  const [atEnd, setAtEnd] = useState(false)
+
+  const syncEdges = useCallback(() => {
+    const el = trackRef.current
+    if (!el) return
+    // 4px — запас на дробные значения scrollLeft при масштабировании страницы.
+    setAtStart(el.scrollLeft <= 4)
+    setAtEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 4)
+  }, [])
+
+  useEffect(() => {
+    syncEdges()
+    window.addEventListener('resize', syncEdges)
+    return () => window.removeEventListener('resize', syncEdges)
+  }, [syncEdges])
+
+  function scroll(dir: 'left' | 'right') {
+    const el = trackRef.current
+    if (!el) return
+    const card = el.firstElementChild as HTMLElement | null
+    // Шаг — ширина карточки с отступом (gap-6 = 24px), запасной вариант —
+    // видимая ширина ленты, если карточек почему-то нет.
+    const step = card ? card.offsetWidth + 24 : el.clientWidth
+    el.scrollBy({ left: dir === 'left' ? -step : step, behavior: 'smooth' })
+  }
+
+  if (BLOG_POSTS.length === 0) return null
+
+  return (
+    <section id="blog" className="py-24 border-t border-slate-200 dark:border-slate-900">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-wrap items-end justify-between gap-6 mb-10">
+          <div>
+            <h2 className="text-3xl md:text-4xl font-bold mb-3">Свежее в блоге</h2>
+            <p className="text-slate-500 dark:text-slate-400 max-w-2xl">
+              Разборы проектов, кейсы заказчиков и то, как устроена платформа изнутри
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {/* Стрелки — только там, где нет свайпа: на тач-экранах лента листается пальцем. */}
+            <div className="hidden md:flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => scroll('left')}
+                disabled={atStart}
+                className="w-10 h-10 flex items-center justify-center rounded-full border border-slate-200 dark:border-slate-800 text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:border-blue-500/40 disabled:opacity-30 disabled:hover:text-slate-500 disabled:hover:border-slate-200 dark:disabled:hover:border-slate-800 disabled:cursor-default transition-all"
+                aria-label="Предыдущие статьи"
+              >
+                <ChevronLeft size={18} />
+              </button>
+              <button
+                type="button"
+                onClick={() => scroll('right')}
+                disabled={atEnd}
+                className="w-10 h-10 flex items-center justify-center rounded-full border border-slate-200 dark:border-slate-800 text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:border-blue-500/40 disabled:opacity-30 disabled:hover:text-slate-500 disabled:hover:border-slate-200 dark:disabled:hover:border-slate-800 disabled:cursor-default transition-all"
+                aria-label="Следующие статьи"
+              >
+                <ChevronRight size={18} />
+              </button>
+            </div>
+
+            <a
+              href={`${BLOG_URL}/`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold transition-colors shadow-sm"
+            >
+              Перейти в блог <ArrowRight size={16} />
+            </a>
+          </div>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
+          <div
+            ref={trackRef}
+            onScroll={syncEdges}
+            className="flex gap-6 overflow-x-auto scrollbar-none snap-x snap-mandatory pb-2 -mx-4 px-4 sm:mx-0 sm:px-0"
+          >
+            {BLOG_POSTS.map((post) => (
+              <a
+                key={post.slug}
+                href={post.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group snap-start flex-shrink-0 w-[82%] sm:w-[48%] lg:w-[32%] flex flex-col bg-white dark:bg-slate-900/40 border border-slate-200 dark:border-slate-800 rounded-2xl overflow-hidden hover:border-blue-500/40 hover:shadow-md transition-all"
+              >
+                <div className="aspect-[16/9] overflow-hidden bg-slate-100 dark:bg-slate-900">
+                  <img
+                    src={post.image}
+                    alt=""
+                    loading="lazy"
+                    className="w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-500"
+                  />
+                </div>
+                <div className="flex flex-col flex-1 gap-3 p-5">
+                  <div className="flex items-center gap-2 text-xs">
+                    <span className="px-2 py-0.5 rounded-full bg-blue-600/10 text-blue-600 dark:text-blue-400 font-semibold">
+                      {post.category}
+                    </span>
+                    <time dateTime={post.date} className="text-slate-400 dark:text-slate-500">
+                      {post.dateLabel}
+                    </time>
+                  </div>
+                  <h3 className="text-lg font-bold leading-snug line-clamp-2 text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                    {post.title}
+                  </h3>
+                  <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed line-clamp-3 flex-1">
+                    {post.description}
+                  </p>
+                  <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 dark:text-blue-400">
+                    Читать <ArrowRight size={15} className="group-hover:translate-x-0.5 transition-transform" />
+                  </span>
+                </div>
+              </a>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  )
+}

--- a/src/data/blogPosts.d.ts
+++ b/src/data/blogPosts.d.ts
@@ -1,0 +1,21 @@
+// Типы для src/data/blogPosts.mjs (plain-ESM data, общий для React и пререндера).
+// Сам файл генерируется: scripts/generate-blog-posts.mjs (npm run blog-posts).
+
+export interface BlogPost {
+  /** Слаг статьи в блоге — имя md-файла без расширения. */
+  slug: string
+  /** Абсолютный адрес статьи на blog.ideav.ru. */
+  url: string
+  title: string
+  description: string
+  /** Дата публикации в ISO (YYYY-MM-DD) — для сортировки и <time datetime>. */
+  date: string
+  /** Та же дата по-русски: «17 июля 2026». */
+  dateLabel: string
+  category: string
+  /** Абсолютный адрес обложки (или абстрактной заглушки) на blog.ideav.ru. */
+  image: string
+}
+
+export const BLOG_URL: string
+export const BLOG_POSTS: BlogPost[]

--- a/src/data/blogPosts.mjs
+++ b/src/data/blogPosts.mjs
@@ -1,0 +1,102 @@
+// Сгенерировано скриптом scripts/generate-blog-posts.mjs — руками не править.
+// Источник: blog-v2/src/content/posts/*.md. Обновить: npm run blog-posts.
+//
+// Свежие статьи блога для слайдера на главной (issue #512). Блог — отдельная
+// Astro-сборка на blog.ideav.ru, поэтому список «запекается» в данные на этапе
+// сборки: файл импортируют и React (src/components/BlogSlider.tsx), и Node-скрипт
+// пререндера главной (scripts/prerender-landing.mjs). Типы — src/data/blogPosts.d.ts.
+
+export const BLOG_URL = 'https://blog.ideav.ru'
+
+export const BLOG_POSTS = [
+  {
+    slug: 'promyshlennoe-prilozhenie-shansy-riski-trudoemkost',
+    url: 'https://blog.ideav.ru/posts/promyshlennoe-prilozhenie-shansy-riski-trudoemkost/',
+    title: 'Оценка в 300 часов: как взвесить шансы, риски и трудоёмкость промышленного приложения',
+    description: 'Разбор реальной оценки: 40 экранов, 77 эндпоинтов, 90 действий — откуда берутся 300 часов и почему «сгенерируется за пару часов» этому не противоречит. Данные исследований о том, где стопорятся те, кто собирает систему сам, и три модели разработки одной и той же системы с цифрами.',
+    date: '2026-07-28',
+    dateLabel: '28 июля 2026',
+    category: 'Разработка',
+    image: 'https://blog.ideav.ru/uploads/trudoemkost-90-deistvii-cover.png',
+  },
+  {
+    slug: 'pravila-kotorye-nelzya-narushit',
+    url: 'https://blog.ideav.ru/posts/pravila-kotorye-nelzya-narushit/',
+    title: 'Правила, которые нельзя нарушить: как сделать разработку сходящейся',
+    description: 'Почему одни и те же дефекты возвращаются тикетами, даже когда задачи поставлены внятно, и как перестроить процесс — реестр инвариантов, единая граница записи, тест «входы × правила» и обязательный гейт. Практика из наших проектов и типовых случаев.',
+    date: '2026-07-27',
+    dateLabel: '27 июля 2026',
+    category: 'Разработка',
+    image: 'https://blog.ideav.ru/uploads/pravila-invarianty-cover.png',
+  },
+  {
+    slug: 'pure-business-design-chistoe-biznes-proektirovanie',
+    url: 'https://blog.ideav.ru/posts/pure-business-design-chistoe-biznes-proektirovanie/',
+    title: 'Pure Business Design: приложение по описанию задачи, без блоков и кубиков',
+    description: 'Чистое бизнес-проектирование — когда пользователь думает только о логике своего дела, а структуру базы, связи, роли, меню и интерфейс проектирует ИИ-агент. Чем это отличается от визуальных конструкторов и от ИИ-ассистентов, которым нужен человек на каждой итерации.',
+    date: '2026-07-24',
+    dateLabel: '24 июля 2026',
+    category: 'О платформе',
+    image: 'https://blog.ideav.ru/uploads/og/hero-ai-background.jpg',
+  },
+  {
+    slug: 'semeynyi-byudzhet-v-integrame',
+    url: 'https://blog.ideav.ru/posts/semeynyi-byudzhet-v-integrame/',
+    title: 'Семейный бюджет в Интеграме: от Excel к приложению за один запрос',
+    description: 'Как собрать семейный бюджет в Интеграме — разбор готового приложения по экранам. Счета с автоподсчётом остатка, план и факт по категориям, цели накопления, долги и рассрочки, регулярные платежи одной кнопкой и фото чека к операции. Со скриншотами каждого экрана и объяснением, как это устроено.',
+    date: '2026-07-17',
+    dateLabel: '17 июля 2026',
+    category: 'Проекты',
+    image: 'https://blog.ideav.ru/uploads/og/semeynyi-byudzhet-svodka.jpg',
+  },
+  {
+    slug: 'bezopasnost-i-otkazoustoichivost-dlya-krupnogo-biznesa',
+    url: 'https://blog.ideav.ru/posts/bezopasnost-i-otkazoustoichivost-dlya-krupnogo-biznesa/',
+    title: 'Безопасность и отказоустойчивость Интеграма: данные крупного бизнеса под контролем',
+    description: 'Как в Интеграме устроена защита данных от посторонних и от потери: обычная СУБД, гибкая топология развёртывания, шифрование и георезервирование, а главное — выгрузка данных в Excel и реляционную БД без вендор-лока.',
+    date: '2026-07-16',
+    dateLabel: '16 июля 2026',
+    category: 'О платформе',
+    image: 'https://blog.ideav.ru/abstract/blog-material-5.svg',
+  },
+  {
+    slug: 'integram-fc-chto-poluchilos-razbor-po-ekranam',
+    url: 'https://blog.ideav.ru/posts/integram-fc-chto-poluchilos-razbor-po-ekranam/',
+    title: 'ИНТЕГРАМ FC изнутри: разбираем готовое приложение по экранам',
+    description: 'Подробный разбор готового приложения «ИНТЕГРАМ FC» — вирусного футбольного антитотализатора, который ИИ собрал за двадцать минут. Со скриншотами каждого экрана: дэшборд-табло, матчи, команды, турнирные таблицы, ставки в антиформате и вирусные звания. Часть 2: что получилось.',
+    date: '2026-06-27',
+    dateLabel: '27 июня 2026',
+    category: 'Проекты',
+    image: 'https://blog.ideav.ru/uploads/og/integram-fc-dashboard.jpg',
+  },
+  {
+    slug: 'integram-fc-kak-delali-ot-zayavki-do-prilozheniya',
+    url: 'https://blog.ideav.ru/posts/integram-fc-kak-delali-ot-zayavki-do-prilozheniya/',
+    title: 'ИНТЕГРАМ FC: как из одного абзаца заказчика вырос вирусный антитотализатор',
+    description: 'История одного проекта от начала и до конца — как ИИ превратил абзац «сделай игру, которая будет вируситься» в техзадание, а потом в работающее приложение со схемой данных, ролями и тестовыми данными. Часть 1: как делали.',
+    date: '2026-06-27',
+    dateLabel: '27 июня 2026',
+    category: 'Проекты',
+    image: 'https://blog.ideav.ru/uploads/og/integram-fc-tables.jpg',
+  },
+  {
+    slug: 'massovoe-sopostavlenie-katalogov',
+    url: 'https://blog.ideav.ru/posts/massovoe-sopostavlenie-katalogov/',
+    title: 'Массовое сопоставление каталогов в Интеграме: автоматический подбор пар',
+    description: 'Продолжаем тему сопоставления каталогов: массовый автоподбор в несколько потоков, как считается оценка точности, кандидаты-альтернативы, выгрузка в Excel и доуточнение шорт-листа языковой моделью — без программирования.',
+    date: '2026-06-23',
+    dateLabel: '23 июня 2026',
+    category: 'Обучение',
+    image: 'https://blog.ideav.ru/uploads/og/e09f9acc-matching-results.jpg',
+  },
+  {
+    slug: 'ii-chat-vnutri-bazy-agent-dorabatyvaet-prilozhenie',
+    url: 'https://blog.ideav.ru/posts/ii-chat-vnutri-bazy-agent-dorabatyvaet-prilozhenie/',
+    title: 'ИИ-чат внутри приложения: тот же агент дорабатывает базу изнутри',
+    description: 'В каждой базе Интеграма появился ИИ-чат, который вызывает того же агента-разработчика — он дорабатывает приложение прямо изнутри. Рассказываем, как это выглядит, что можно просить и как устроены доступ и безопасность.',
+    date: '2026-06-17',
+    dateLabel: '17 июня 2026',
+    category: 'О платформе',
+    image: 'https://blog.ideav.ru/uploads/og/ii-chat-vnutri-bazy.jpg',
+  },
+]

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -41,6 +41,7 @@ import { Link } from 'react-router-dom'
 import { USE_CASES } from '../data/usecases'
 import { HOME_FAQ } from '../data/home-faq'
 import ClientLogos from '@/components/ClientLogos'
+import BlogSlider from '@/components/BlogSlider'
 
 declare global {
   interface Window {
@@ -1089,6 +1090,9 @@ export default function Home() {
           </div>
         </div>
       </section>
+
+      {/* 9d. Свежие статьи блога (issue #512) — данные из src/data/blogPosts.mjs */}
+      <BlogSlider />
 
       {/* 10. Pricing Section */}
       <section id="pricing" className="py-24 bg-slate-50 dark:bg-slate-900/50">

--- a/tests/issue-512-blog-slider.test.mjs
+++ b/tests/issue-512-blog-slider.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * issue #512 — на главной есть слайдер статей блога с кнопкой «Перейти в блог».
+ *
+ * Блог собирается отдельно (Astro → blog.ideav.ru), поэтому список статей
+ * запекается в src/data/blogPosts.mjs скриптом scripts/generate-blog-posts.mjs.
+ * Тест сторожит три вещи: данные совпадают с исходным контентом блога, слайдер
+ * действительно подключён к главной, и статичный снапшот (пререндер) показывает
+ * те же статьи — иначе краулеры увидят главную без блока блога.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { execFileSync } from 'node:child_process'
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { readBlogPosts, SLIDER_LIMIT } from '../scripts/lib/blog-posts.mjs'
+import { BLOG_URL, BLOG_POSTS } from '../src/data/blogPosts.mjs'
+
+const repo = new URL('..', import.meta.url).pathname
+const read = (path) => readFileSync(resolve(repo, path), 'utf8')
+
+test('src/data/blogPosts.mjs совпадает с контентом блога', () => {
+  const expected = readBlogPosts(SLIDER_LIMIT)
+
+  assert.equal(
+    BLOG_POSTS.length,
+    expected.length,
+    'данные устарели — обновите их командой npm run blog-posts',
+  )
+  assert.deepEqual(
+    BLOG_POSTS,
+    expected,
+    'src/data/blogPosts.mjs разошёлся с blog-v2/src/content/posts — npm run blog-posts',
+  )
+})
+
+test('в слайдере — свежие статьи с рабочими ссылками на blog.ideav.ru', () => {
+  assert.equal(BLOG_URL, 'https://blog.ideav.ru')
+  assert.ok(BLOG_POSTS.length >= 3, 'слайдеру нужно хотя бы несколько статей')
+
+  const dates = BLOG_POSTS.map((p) => p.date)
+  assert.deepEqual(dates, [...dates].sort().reverse(), 'статьи идут от новой к старой')
+
+  for (const post of BLOG_POSTS) {
+    assert.equal(post.url, `${BLOG_URL}/posts/${post.slug}/`)
+    assert.ok(post.title, `нет заголовка у ${post.slug}`)
+    assert.ok(post.image.startsWith(`${BLOG_URL}/`), `обложка ${post.slug} не абсолютная`)
+    assert.match(post.date, /^\d{4}-\d{2}-\d{2}$/)
+    assert.ok(post.dateLabel.length > 0, `нет русской даты у ${post.slug}`)
+  }
+
+  // Слаги уникальны: дубль означал бы, что одна статья заняла два слота.
+  assert.equal(new Set(BLOG_POSTS.map((p) => p.slug)).size, BLOG_POSTS.length)
+})
+
+test('слайдер подключён к главной и ведёт в блог по кнопке', () => {
+  const home = read('src/pages/Home.tsx')
+  assert.match(home, /import BlogSlider from '@\/components\/BlogSlider'/)
+  assert.match(home, /<BlogSlider \/>/)
+
+  const slider = read('src/components/BlogSlider.tsx')
+  assert.match(slider, /import \{ BLOG_URL, BLOG_POSTS \} from '\.\.\/data\/blogPosts'/)
+  assert.match(slider, /Перейти в блог/)
+  assert.match(slider, /href=\{`\$\{BLOG_URL\}\/`\}/)
+  // Карточки уходят на внешний домен — только новой вкладкой и без noopener-дыры.
+  assert.match(slider, /rel="noopener noreferrer"/)
+})
+
+test('сборка обновляет данные блога до vite build', () => {
+  const pkg = JSON.parse(read('package.json'))
+  assert.equal(pkg.scripts['blog-posts'], 'node scripts/generate-blog-posts.mjs')
+
+  const build = pkg.scripts.build
+  assert.match(build, /generate-blog-posts\.mjs/)
+  assert.ok(
+    build.indexOf('generate-blog-posts.mjs') < build.indexOf('vite build'),
+    'данные блога должны генерироваться до сборки SPA',
+  )
+})
+
+test('пререндер главной показывает статьи блога без JS', () => {
+  const work = mkdtempSync(resolve(tmpdir(), 'blog-slider-'))
+  mkdirSync(resolve(work, 'dist'), { recursive: true })
+  mkdirSync(resolve(work, 'scripts'), { recursive: true })
+  cpSync(resolve(repo, 'scripts/prerender-landing.mjs'), resolve(work, 'scripts/prerender-landing.mjs'))
+  cpSync(resolve(repo, 'src/data'), resolve(work, 'src/data'), { recursive: true })
+  writeFileSync(resolve(work, 'dist/index.html'), read('index.html'))
+
+  execFileSync('node', ['scripts/prerender-landing.mjs'], { cwd: work })
+  const out = readFileSync(resolve(work, 'dist/index.html'), 'utf8')
+
+  assert.match(out, /Свежее в блоге/)
+  assert.match(out, new RegExp(`<a href="${BLOG_URL}/">Перейти в блог</a>`))
+  for (const post of BLOG_POSTS) {
+    assert.ok(out.includes(post.url), `в снапшоте нет ссылки на ${post.slug}`)
+  }
+})


### PR DESCRIPTION
Fixes #512

## Что сделано

На главной, между блоком «Все решения и инструменты» и тарифами, появилась секция **«Свежее в блоге»**: горизонтальный слайдер из **9 последних статей** blog.ideav.ru и кнопка **«Перейти в блог»**.

- карточка: обложка 16:9, категория, дата, заголовок, описание, «Читать →»; открывается в новой вкладке (`rel="noopener noreferrer"`);
- прокрутка нативная — scroll-snap и свайп пальцем; стрелки (только на десктопе) сдвигают ленту ровно на карточку и гаснут на краях, своей анимации нет — рассинхронизироваться с реальным положением ленты нечему;
- на мобильном карточка занимает 82% ширины, следующая «выглядывает» — видно, что лента листается; горизонтального переполнения страницы нет.

## Откуда берутся статьи

Блог — отдельная Astro-сборка на своём домене, дотянуться до его контента в рантайме React-приложение не может. Поэтому список запекается на этапе сборки:

- `scripts/lib/blog-posts.mjs` — читает `blog-v2/src/content/posts/*.md` без зависимостей (мини-парсер фронтматтера), фильтрует `draft`, сортирует как сам блог;
- `scripts/generate-blog-posts.mjs` → `src/data/blogPosts.mjs` (коммитится: нужен и `vite dev`, и пререндеру). Первый шаг `npm run build`, вручную — `npm run blog-posts`;
- обложка выбирается как в блоге: `image:` из фронтматтера → первая картинка из текста → абстрактная заглушка. Если у обложки есть готовый OG-вариант 1200×630 (`/uploads/og/…`) — берём его: легче исходного скриншота и одинаковое соотношение сторон во всех карточках.

## Пререндер

Тот же модуль читает `scripts/prerender-landing.mjs`, поэтому статьи и ссылка на блог есть и в статичном снапшоте главной — иначе краулеры (особенно Яндекс) и клиенты без JS блока бы не увидели, а ссылочный вес на blog.ideav.ru с главной не передавался.

## Проверено

- `npm run build` — сборка проходит, в `dist/index.html` есть «Свежее в блоге» и 9 ссылок на статьи; повторный прогон генератора файл не меняет (идемпотентно);
- `npx tsc --noEmit` — чисто;
- `npm test` — 5 новых тестов (`tests/issue-512-blog-slider.test.mjs`) зелёные; 14 падений на ветке — ровно те же, что на `origin/main` (php-тесты, роуты, статьи БЗ, тема) — не связаны с правкой;
- вживую в браузере: светлая/тёмная тема, десктоп 1440 и мобильный 390, стрелки и края ленты, ссылки на blog.ideav.ru и обложки отдают 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)