### PR TITLE
SEO(#514): бюджет заголовков главной — 83 → 22, H4 убраны, FAQ размечен dl/dt/dd

### DIFF
--- a/scripts/prerender-landing.mjs
+++ b/scripts/prerender-landing.mjs
@@ -120,21 +120,26 @@ const blogHtml = `
         <p><a href="${escape(BLOG_URL)}/">Перейти в блог</a></p>
       </section>`
 
+// Вопросы — списком определений, а не заголовками: семь H3 подряд размывали
+// структуру документа, а поисковику вопросы и ответы отдаёт разметка FAQPage
+// ниже (issue #514). Так же размечен живой блок в src/pages/Home.tsx.
 const faqHtml = `
       <section class="lp-prerender__group" aria-labelledby="lp-faq-title">
         <h2 id="lp-faq-title">Частые вопросы</h2>
+        <dl>
         ${HOME_FAQ
           .map(
             (item) => `<div class="lp-prerender__faq-item">
-          <h3>${escape(item.q)}</h3>
-          <p>${escape(item.a)}</p>${
+          <dt>${escape(item.q)}</dt>
+          <dd>${escape(item.a)}${
             item.link
-              ? `\n          <p class="lp-prerender__faq-link"><a href="${escape(item.link.href)}">${escape(item.link.text)}</a></p>`
+              ? `\n          <span class="lp-prerender__faq-link"><a href="${escape(item.link.href)}">${escape(item.link.text)}</a></span>`
               : ''
-          }
+          }</dd>
         </div>`
           )
           .join('\n        ')}
+        </dl>
       </section>`
 
 // Ссылки на все страницы-решения — чтобы краулеры видели их в статичном
@@ -201,8 +206,9 @@ const bodyHtml = `
   #lp-prerender .lp-prerender__posts li { margin: 0.5rem 0; }
   #lp-prerender .lp-prerender__post-meta { display: block; font-size: 0.85rem; color: #64748b; }
   #lp-prerender .lp-prerender__faq-item { margin: 1rem 0; }
-  #lp-prerender .lp-prerender__faq-item h3 { font-size: 1.05rem; margin: 0 0 0.25rem; }
-  #lp-prerender .lp-prerender__faq-link { font-size: 0.92rem; }
+  #lp-prerender .lp-prerender__faq-item dt { font-size: 1.05rem; font-weight: 700; margin: 0 0 0.25rem; }
+  #lp-prerender .lp-prerender__faq-item dd { margin: 0; line-height: 1.6; }
+  #lp-prerender .lp-prerender__faq-link { display: block; margin-top: 0.35rem; font-size: 0.92rem; }
   #lp-prerender a { color: #2563eb; }
   #lp-prerender .lp-prerender__footer { margin-top: 3rem; padding-top: 1.5rem;
     border-top: 1px solid #e2e8f0; font-size: 0.92rem; color: #475569; }

--- a/src/components/BlogSlider.tsx
+++ b/src/components/BlogSlider.tsx
@@ -51,7 +51,9 @@ export default function BlogSlider() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex flex-wrap items-end justify-between gap-6 mb-10">
           <div>
-            <h2 className="text-3xl md:text-4xl font-bold mb-3">Свежее в блоге</h2>
+            {/* Заголовок ленты — не <h2>: это виджет-подборка, а не смысловой раздел
+                страницы. Девять карточек с <h3> раздували структуру главной (issue #514). */}
+            <p className="text-3xl md:text-4xl font-bold mb-3">Свежее в блоге</p>
             <p className="text-slate-500 dark:text-slate-400 max-w-2xl">
               Разборы проектов, кейсы заказчиков и то, как устроена платформа изнутри
             </p>
@@ -127,9 +129,9 @@ export default function BlogSlider() {
                       {post.dateLabel}
                     </time>
                   </div>
-                  <h3 className="text-lg font-bold leading-snug line-clamp-2 text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                  <p className="text-lg font-bold leading-snug line-clamp-2 text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
                     {post.title}
-                  </h3>
+                  </p>
                   <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed line-clamp-3 flex-1">
                     {post.description}
                   </p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,7 +26,7 @@ export function Footer() {
 
           {/* Quick Links */}
           <div>
-            <h3 className="text-slate-800 dark:text-slate-100 font-semibold mb-6">Продукт</h3>
+            <p className="text-slate-800 dark:text-slate-100 font-semibold mb-6">Продукт</p>
             <ul className="space-y-4">
               <li><a href="/#technology" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Технология</a></li>
               <li><a href="/#process" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">Схема работы</a></li>
@@ -37,7 +37,7 @@ export function Footer() {
 
           {/* Documentation / Legal */}
           <div>
-            <h3 className="text-slate-800 dark:text-slate-100 font-semibold mb-6">Ресурсы</h3>
+            <p className="text-slate-800 dark:text-slate-100 font-semibold mb-6">Ресурсы</p>
             <ul className="space-y-4">
               <li><a href="https://help.integram.io/" target="_blank" rel="noopener noreferrer" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors flex items-center gap-2">Документация <ExternalLink size={12} /></a></li>
               <li><Link to="/knowledge-base.html" className="text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">База знаний</Link></li>
@@ -54,7 +54,7 @@ export function Footer() {
 
           {/* Contacts */}
           <div id="contacts">
-            <h3 className="text-slate-800 dark:text-slate-100 font-semibold mb-6">Контакты</h3>
+            <p className="text-slate-800 dark:text-slate-100 font-semibold mb-6">Контакты</p>
             <ul className="space-y-4">
               <li>
                 <a href="https://t.me/qdmadept" className="flex items-center gap-3 text-slate-500 dark:text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 text-sm transition-colors">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -163,6 +163,11 @@ export default function Home() {
   }
 
   return (
+    // Бюджет заголовков (issue #514): один H1, до 10 H2 — только смысловые
+    // разделы страницы, до 15 H3 — их подпункты (кейсы, тарифы, модели старта).
+    // Подписи карточек, шаги, отрасли, вопросы FAQ и заголовки промо-блоков —
+    // обычный текст с теми же классами: было 83 заголовка на 2800 слов, и
+    // «скелет» страницы для поисковика размывался. Тест — tests/issue-514-headings.
     <div className="overflow-hidden">
       {/* 1. Hero Section */}
       <section className="relative isolate overflow-hidden pt-32 pb-20 lg:pt-48 lg:pb-32">
@@ -271,9 +276,9 @@ export default function Home() {
               <div className="text-xs font-bold text-blue-600 dark:text-blue-400 uppercase tracking-widest mb-1">
                 Новое · готово за ~45 минут
               </div>
-              <h2 className="text-2xl md:text-3xl font-bold mb-1">
+              <p className="text-2xl md:text-3xl font-bold mb-1">
                 Загрузите Excel — получите приложение
-              </h2>
+              </p>
               <p className="text-slate-500 dark:text-slate-400">
                 Конвертация Excel в приложение без потерь данных. Пришлите свои таблицы — вернём ссылку на готовую базу Интеграм с вашими данными: формы ввода, права доступа, отчёты и дашборды.
               </p>
@@ -339,7 +344,7 @@ export default function Home() {
                       <Code2 size={20} />
                     </div>
                     <div>
-                      <h3 className="font-semibold text-slate-800 dark:text-slate-100 mb-1">{item.title}</h3>
+                      <p className="font-semibold text-slate-800 dark:text-slate-100 mb-1">{item.title}</p>
                       <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">{item.desc}</p>
                       {item.href && item.linkText && (
                         <Link
@@ -430,7 +435,7 @@ export default function Home() {
               { label: 'ИТ-компании', desc: 'Service Desk, управление заявками и инцидентами, Help Desk для ИТ-отдела. Автоматизация рутинных задач в офисе.', href: '/baza-zayavok.html', linkText: 'Учёт заявок вместо Excel' },
             ].map(({ label, desc, href, linkText }) => (
               <div key={label} className="p-5 rounded-2xl bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800">
-                <h3 className="font-bold text-slate-800 dark:text-slate-100 mb-1">{label}</h3>
+                <p className="font-bold text-slate-800 dark:text-slate-100 mb-1">{label}</p>
                 <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">{desc}</p>
                 <Link
                   to={href}
@@ -509,7 +514,7 @@ export default function Home() {
                 <div className="w-14 h-14 rounded-2xl bg-blue-600/10 flex items-center justify-center text-blue-500 mb-6 group-hover:scale-110 transition-transform">
                   <item.icon size={28} />
                 </div>
-                <h3 className="text-xl font-bold mb-4">{item.title}</h3>
+                <p className="text-xl font-bold mb-4">{item.title}</p>
                 <p className="text-slate-500 dark:text-slate-400 leading-relaxed">{item.desc}</p>
                 {/* Перелинковка на разбор в базе знаний (issue #495) */}
                 <Link
@@ -564,7 +569,7 @@ export default function Home() {
                 <div className="text-4xl font-black text-slate-100 dark:text-slate-900 group-hover:text-blue-500/10 transition-colors absolute top-4 right-6 leading-none">
                   {item.step}
                 </div>
-                <h3 className="text-xl font-bold mb-4 text-slate-800 dark:text-slate-100 group-hover:text-blue-500 transition-colors">{item.title}</h3>
+                <p className="text-xl font-bold mb-4 text-slate-800 dark:text-slate-100 group-hover:text-blue-500 transition-colors">{item.title}</p>
                 <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">{item.desc}</p>
               </motion.div>
             ))}
@@ -596,14 +601,14 @@ export default function Home() {
                   <div className="w-10 h-10 rounded-lg bg-slate-100 dark:bg-slate-800 flex items-center justify-center text-blue-500 mb-4">
                     <item.icon size={20} />
                   </div>
-                  <h4 className="font-bold text-slate-800 dark:text-slate-100 mb-1">{item.label}</h4>
+                  <p className="font-bold text-slate-800 dark:text-slate-100 mb-1">{item.label}</p>
                   <p className="text-xs text-slate-400 dark:text-slate-500 uppercase tracking-wider">{item.sub}</p>
                 </div>
               ))}
             </div>
 
             <div className="order-1 lg:order-2">
-              <h2 className="text-3xl md:text-4xl font-bold mb-6">Изменения вносятся бизнес-аналитиками, а не программистами</h2>
+              <p className="text-3xl md:text-4xl font-bold mb-6">Изменения вносятся бизнес-аналитиками, а не программистами</p>
               <p className="text-slate-500 dark:text-slate-400 text-lg mb-8 leading-relaxed">
                 Ваши ИТ-ресурсы перестают тратить время на правки отчётов и интерфейсов. Поля, формы, отчёты и дашборды настраиваются без релизов. Это no-code платформа: автоматизация бизнес-процессов без программирования. Создание веб-приложений для аналитиков — без кода, без ожидания очереди к разработчикам.
               </p>
@@ -684,7 +689,7 @@ export default function Home() {
                 <div className="w-12 h-12 rounded-xl bg-blue-500/10 border border-blue-500/20 flex items-center justify-center text-blue-500 dark:text-blue-400 mb-5">
                   <item.icon size={22} />
                 </div>
-                <h3 className="font-bold text-slate-800 dark:text-slate-100 mb-2">{item.title}</h3>
+                <p className="font-bold text-slate-800 dark:text-slate-100 mb-2">{item.title}</p>
                 <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">{item.desc}</p>
               </motion.div>
             ))}
@@ -698,7 +703,7 @@ export default function Home() {
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl md:text-4xl font-bold mb-4">Мы не заменяем, мы дополняем</h2>
+            <p className="text-3xl md:text-4xl font-bold mb-4">Мы не заменяем, мы дополняем</p>
             <p className="text-slate-500 dark:text-slate-400 max-w-2xl mx-auto">Инструмент, который бесшовно встраивается в ваш существующий ИТ-ландшафт.</p>
           </div>
 
@@ -713,7 +718,7 @@ export default function Home() {
                 <div className="mx-auto w-12 h-12 rounded-xl bg-blue-500/10 flex items-center justify-center text-blue-500 mb-6">
                   <item.icon size={24} />
                 </div>
-                <h3 className="font-bold mb-2">{item.title}</h3>
+                <p className="font-bold mb-2">{item.title}</p>
                 <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">{item.desc || item.sub}</p>
               </div>
             ))}
@@ -757,7 +762,7 @@ export default function Home() {
                       <ArrowRight size={14} className="rotate-45" />
                     </div>
                     <div>
-                      <h4 className="text-sm font-bold text-slate-700 dark:text-slate-200">Задача:</h4>
+                      <p className="text-sm font-bold text-slate-700 dark:text-slate-200">Задача:</p>
                       <p className="text-sm text-slate-500 dark:text-slate-400">Регистрация, адаптация, заведение проектов, распределение задач, процесс выполнения проекта.</p>
                     </div>
                   </div>
@@ -766,7 +771,7 @@ export default function Home() {
                       <CheckCircle2 size={14} />
                     </div>
                     <div>
-                      <h4 className="text-sm font-bold text-slate-700 dark:text-slate-200">Реализация:</h4>
+                      <p className="text-sm font-bold text-slate-700 dark:text-slate-200">Реализация:</p>
                       <p className="text-sm text-slate-500 dark:text-slate-400">Структура данных и наполнение, сводная панель метрик, планирование H_min, назначения, мониторинг, экономика и симуляция сценариев.</p>
                     </div>
                   </div>
@@ -866,7 +871,7 @@ export default function Home() {
                       <ArrowRight size={14} className="rotate-45" />
                     </div>
                     <div>
-                      <h4 className="text-sm font-bold text-slate-700 dark:text-slate-200">Задача:</h4>
+                      <p className="text-sm font-bold text-slate-700 dark:text-slate-200">Задача:</p>
                       <p className="text-sm text-slate-500 dark:text-slate-400">Единая методология оценки суверенности по 9 измерениям, проверка соответствия НПА (ПП-1726, ФЗ-149) и дорожная карта.</p>
                     </div>
                   </div>
@@ -875,7 +880,7 @@ export default function Home() {
                       <CheckCircle2 size={14} />
                     </div>
                     <div>
-                      <h4 className="text-sm font-bold text-slate-700 dark:text-slate-200">Реализация:</h4>
+                      <p className="text-sm font-bold text-slate-700 dark:text-slate-200">Реализация:</p>
                       <p className="text-sm text-slate-500 dark:text-slate-400">9D Аудит, пирамида суверенности, моделировщик, анализатор хранилищ кода (50+ метрик) и автоматические дорожные карты.</p>
                     </div>
                   </div>
@@ -927,7 +932,7 @@ export default function Home() {
                       <ArrowRight size={14} className="rotate-45" />
                     </div>
                     <div>
-                      <h4 className="text-sm font-bold text-slate-700 dark:text-slate-200">Задача:</h4>
+                      <p className="text-sm font-bold text-slate-700 dark:text-slate-200">Задача:</p>
                       <p className="text-sm text-slate-500 dark:text-slate-400">Централизованный учет ПДн, версионность, согласование и интеграция с аудитом.</p>
                     </div>
                   </div>
@@ -936,7 +941,7 @@ export default function Home() {
                       <CheckCircle2 size={14} />
                     </div>
                     <div>
-                      <h4 className="text-sm font-bold text-slate-700 dark:text-slate-200">Реализация:</h4>
+                      <p className="text-sm font-bold text-slate-700 dark:text-slate-200">Реализация:</p>
                       <p className="text-sm text-slate-500 dark:text-slate-400">Реестр процессов, автоматическая отчетность без программирования, встроенная ролевая модель.</p>
                     </div>
                   </div>
@@ -989,7 +994,7 @@ export default function Home() {
       <section className="py-24">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl md:text-4xl font-bold mb-4">Готовые типы проектов для вашего бэклога (очереди задач)</h2>
+            <p className="text-3xl md:text-4xl font-bold mb-4">Готовые типы проектов для вашего бэклога (очереди задач)</p>
             <p className="text-slate-500 dark:text-slate-400">Любая из этих задач может быть реализована как полноценное веб-приложение</p>
           </div>
 
@@ -1199,7 +1204,7 @@ export default function Home() {
       <section className="py-24 border-t border-slate-200 dark:border-slate-900 bg-white dark:bg-slate-950/30">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl md:text-4xl font-bold mb-4">Кто работает над вашей задачей</h2>
+            <p className="text-3xl md:text-4xl font-bold mb-4">Кто работает над вашей задачей</p>
             <p className="text-slate-500 dark:text-slate-400 max-w-2xl mx-auto">Мы предоставляем экспертов, которые знают платформу и понимают бизнес-процессы.</p>
           </div>
 
@@ -1209,7 +1214,7 @@ export default function Home() {
                 <Users size={24} />
               </div>
               <div>
-                <h3 className="text-xl font-bold text-slate-800 dark:text-slate-100 mb-2">Системный аналитик</h3>
+                <p className="text-xl font-bold text-slate-800 dark:text-slate-100 mb-2">Системный аналитик</p>
                 <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
                   Сбор требований, проектирование структур данных и логики процессов. Переводит бизнес-язык в архитектуру платформы.
                 </p>
@@ -1221,7 +1226,7 @@ export default function Home() {
                 <Settings2 size={24} />
               </div>
               <div>
-                <h3 className="text-xl font-bold text-slate-800 dark:text-slate-100 mb-2">Разработчик платформы</h3>
+                <p className="text-xl font-bold text-slate-800 dark:text-slate-100 mb-2">Разработчик платформы</p>
                 <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
                   Настройка логики, интеграций и интерфейсов. Обеспечивает бесшовную работу приложения в вашем контуре.
                 </p>
@@ -1242,7 +1247,7 @@ export default function Home() {
             <div className="absolute top-0 right-0 w-64 h-64 bg-blue-600/10 blur-[100px] rounded-full -z-10" />
 
             <div>
-              <h2 className="text-3xl md:text-5xl font-bold mb-8">Готовы разгрузить свой бэклог (очередь задач)?</h2>
+              <p className="text-3xl md:text-5xl font-bold mb-8">Готовы разгрузить свой бэклог (очередь задач)?</p>
               <p className="text-slate-500 dark:text-slate-400 text-lg mb-8">
                 Пришлите описание задачи или проект из очереди, и мы сделаем предварительную оценку архитектуры и сроков за 24 часа
               </p>
@@ -1513,27 +1518,34 @@ export default function Home() {
           </div>
 
           {/* Вопросы — из src/data/home-faq.mjs: тот же источник питает статический
-              снапшот и разметку FAQPage в scripts/prerender-landing.mjs (issue #495). */}
-          <div className="space-y-4">
+              снапшот и разметку FAQPage в scripts/prerender-landing.mjs (issue #495).
+
+              Вопросы размечены списком определений (dl/dt/dd), а не заголовками:
+              семь H3 подряд размывали структуру страницы, а поисковику вопросы и
+              ответы отдаёт разметка FAQPage из снапшота — она даёт расширенный
+              сниппет, чего теги H3 не дают (issue #514). */}
+          <dl className="space-y-4">
             {HOME_FAQ.map((item, i) => (
               <div
                 key={i}
                 className="p-6 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/30"
               >
-                <h3 className="font-bold text-slate-800 dark:text-slate-100 mb-2">{item.q}</h3>
-                <p className="text-slate-500 dark:text-slate-400 leading-relaxed">{item.a}</p>
-                {item.link && (
-                  <Link
-                    to={item.link.href}
-                    className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:gap-2 transition-all"
-                  >
-                    {item.link.text}
-                    <ArrowRight size={15} />
-                  </Link>
-                )}
+                <dt className="font-bold text-slate-800 dark:text-slate-100 mb-2">{item.q}</dt>
+                <dd className="text-slate-500 dark:text-slate-400 leading-relaxed">
+                  <p>{item.a}</p>
+                  {item.link && (
+                    <Link
+                      to={item.link.href}
+                      className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:gap-2 transition-all"
+                    >
+                      {item.link.text}
+                      <ArrowRight size={15} />
+                    </Link>
+                  )}
+                </dd>
               </div>
             ))}
-          </div>
+          </dl>
         </div>
       </section>
       {/* 16. SEO-текст в подвал (af.md блок 14) */}

--- a/tests/issue-514-headings.test.mjs
+++ b/tests/issue-514-headings.test.mjs
@@ -1,0 +1,118 @@
+/**
+ * issue #514 — структура заголовков главной.
+ *
+ * Было: 83 заголовка на ~2800 слов (1 × H1, 17 × H2, 55 × H3, 10 × H4) —
+ * заголовком был выделен почти каждый абзац и каждая карточка, из-за чего
+ * «скелет» страницы для поисковика размывался. Стало: заголовки остались
+ * только у смысловых разделов и их подпунктов, а подписи карточек, вопросы
+ * FAQ и колонки подвала размечены обычным текстом и списками определений.
+ *
+ * Тест сторожит бюджет заголовков в двух местах: в исходниках React (то, что
+ * увидит краулер с исполнением JS) и в статическом снапшоте главной (то, что
+ * увидят все остальные). Ключевое правило — заголовки не генерируются в
+ * `.map()`: именно карточки в циклах раздували счётчик.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { execFileSync } from 'node:child_process'
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { HOME_FAQ } from '../src/data/home-faq.mjs'
+
+const repo = new URL('..', import.meta.url).pathname
+const read = (path) => readFileSync(resolve(repo, path), 'utf8')
+
+/** Все теги-заголовки файла целиком, включая многострочные и <motion.h1>. */
+function headings(source) {
+  return [...source.matchAll(/<(?:motion\.)?(h[1-6])\b[\s\S]*?<\/(?:motion\.)?\1>/g)].map((m) => ({
+    tag: m[1],
+    html: m[0],
+  }))
+}
+
+const HOME_COMPONENTS = [
+  'src/pages/Home.tsx',
+  'src/components/Header.tsx',
+  'src/components/Footer.tsx',
+  'src/components/ClientLogos.tsx',
+  'src/components/BlogSlider.tsx',
+  'src/components/CookieConsent.tsx',
+]
+
+test('на главной один H1 и не больше десяти H2', () => {
+  const home = headings(read('src/pages/Home.tsx'))
+  const byTag = (tag) => home.filter((h) => h.tag === tag).length
+
+  assert.equal(byTag('h1'), 1, 'H1 на странице ровно один')
+  assert.ok(byTag('h2') <= 10, `H2 не больше 10, сейчас ${byTag('h2')}`)
+  assert.ok(byTag('h3') <= 15, `H3 не больше 15, сейчас ${byTag('h3')}`)
+})
+
+test('H4–H6 на главной не используются', () => {
+  for (const file of HOME_COMPONENTS) {
+    const deep = headings(read(file)).filter((h) => ['h4', 'h5', 'h6'].includes(h.tag))
+    assert.deepEqual(
+      deep.map((h) => h.html.slice(0, 60)),
+      [],
+      `${file}: подписи вместо H4–H6 — обычный текст или dl/dt/dd`,
+    )
+  }
+})
+
+test('заголовки не генерируются в циклах по карточкам', () => {
+  // Подпись карточки внутри .map() множится на число элементов: девять статей
+  // блога, десять отраслей, семь вопросов FAQ. Такие заголовки и дали 55 × H3.
+  for (const file of HOME_COMPONENTS) {
+    for (const h of headings(read(file))) {
+      assert.doesNotMatch(
+        h.html,
+        /\{\s*(item|post|label|entry|card|plan|faq)\b/,
+        `${file}: заголовок ${h.tag} печатается из данных цикла — ${h.html.slice(0, 80)}`,
+      )
+    }
+  }
+})
+
+test('вопросы FAQ размечены списком определений, а не заголовками', () => {
+  const home = read('src/pages/Home.tsx')
+  assert.match(home, /<dl className="space-y-4">/)
+  assert.match(home, /<dt className="[^"]*">\{item\.q\}<\/dt>/)
+  assert.match(home, /<dd className="[^"]*">\s*<p>\{item\.a\}<\/p>/)
+})
+
+test('статический снапшот главной держит тот же бюджет заголовков', () => {
+  const work = mkdtempSync(resolve(tmpdir(), 'headings-'))
+  mkdirSync(resolve(work, 'dist'), { recursive: true })
+  mkdirSync(resolve(work, 'scripts'), { recursive: true })
+  cpSync(resolve(repo, 'scripts/prerender-landing.mjs'), resolve(work, 'scripts/prerender-landing.mjs'))
+  cpSync(resolve(repo, 'src/data'), resolve(work, 'src/data'), { recursive: true })
+  writeFileSync(resolve(work, 'dist/index.html'), read('index.html'))
+
+  execFileSync('node', ['scripts/prerender-landing.mjs'], { cwd: work })
+  const out = readFileSync(resolve(work, 'dist/index.html'), 'utf8')
+  const snapshot = out.slice(out.indexOf('<div id="root">'))
+
+  const tags = [...snapshot.matchAll(/<(h[1-6])\b[^>]*>([\s\S]*?)<\/\1>/g)]
+  const count = (tag) => tags.filter((m) => m[1] === tag).length
+
+  assert.equal(count('h1'), 1)
+  assert.ok(count('h2') <= 10, `H2 в снапшоте не больше 10, сейчас ${count('h2')}`)
+  assert.equal(count('h3') + count('h4') + count('h5') + count('h6'), 0)
+
+  // Дублей заголовков (например, отдельные блоки для мобильной и десктопной
+  // вёрстки) в разметке быть не должно — их считает любой SEO-парсер.
+  const texts = tags.map((m) => m[2].replace(/<[^>]+>/g, '').trim())
+  assert.equal(new Set(texts).size, texts.length, `дубли заголовков: ${texts.join(' | ')}`)
+
+  // Вопросы ушли из заголовков в dt/dd, но остались в разметке FAQPage —
+  // именно она даёт расширенный сниппет в выдаче.
+  for (const item of HOME_FAQ) {
+    assert.ok(snapshot.includes(`<dt>${item.q}</dt>`), `нет <dt> для вопроса: ${item.q}`)
+  }
+  const ld = JSON.parse(
+    out.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)[1].replace(/\\u003c/g, '<'),
+  )
+  const faqNode = ld['@graph'].find((n) => n['@type'] === 'FAQPage')
+  assert.equal(faqNode.mainEntity.length, HOME_FAQ.length)
+})


### PR DESCRIPTION
Fixes #514

## Что было и что стало (замерено в браузере на собранной странице)

| | H1 | H2 | H3 | H4 | Всего | Слов на заголовок |
|---|---|---|---|---|---|---|
| было | 1 | 17 | 55 | 10 | **83** | 39 |
| стало | 1 | **10** | **11** | **0** | **22** | **128** |

Объём текста прежний — 2807 слов. Целевая пропорция из тикета (1 заголовок на 100–200 слов, суммарно 15–25) выдержана.

**Важно: текст страницы не изменился ни на слово.** Заголовки заменены на обычные элементы с теми же классами (Tailwind-preflight обнуляет отступы у `h1–h6` и `p` одинаково), поэтому вёрстка визуально прежняя — проверено скриншотами.

## Что осталось заголовком

- **H1** — один, прежний.
- **H2 (10)** — только смысловые разделы: «Своя разработка — это хорошо, но…», «Для кого», «Работаем там, где обычные конструкторы падают», «Пришлите задачу…», ИИ-раздел, «Примеры из практики», «Все решения и инструменты», «Как начать быстро и комфортно», «Тарифы на хостинг в облаке», FAQ. Все якоря из меню (`#technology`, `#process`, `#cases`, `#pricing`, `#faq`) заголовок сохранили.
- **H3 (11)** — подпункты внутри своих H2: 3 кейса, 2 подрубрики блока решений, 3 модели старта, 3 тарифа.

## Что перестало быть заголовком

- **H4 → 0**: метки «Задача:»/«Реализация:» в кейсах (6 шт.) и подписи карточек возможностей (4 шт.) — обычный текст.
- **H3 → текст**: отрасли в «Для кого», карточки технологий, шаги процесса, карточки ИИ-раздела, «Интеграции/Аутентификация/Мониторинг/Локальная установка», роли команды, 9 карточек ленты блога, три колонки подвала.
- **H2 → текст**: промо-строка «Загрузите Excel — получите приложение», «Изменения вносятся бизнес-аналитиками…», «Мы не заменяем, мы дополняем», «Готовые типы проектов…», «Кто работает над вашей задачей», CTA «Готовы разгрузить свой бэклог?», «Свежее в блоге» — это промо-строки, карточные блоки и виджет, а не разделы страницы.

## FAQ

Семь вопросов вместо `<h3>` размечены списком определений `<dl>/<dt>/<dd>` — и в живой странице, и в статичном снапшоте. Микроразметка **FAQPage** уже была и покрывает все семь вопросов из одного источника `src/data/home-faq.mjs` (снапшот главной кладёт её в `<head>`, так что её видят и краулеры с JS, и без) — именно она даёт расширенный сниппет, чего теги H3 не дают.

## Про дубли заголовков (шаг 4 из тикета)

Проверил DOM собранной страницы: **дублей нет** — ни одного повторяющегося текста заголовка, отдельной мобильной копии блоков в разметке не существует. Расхождение «70 против 80» у SEO-парсеров объяснялось карточками в `.map()`: девять статей блога, десять отраслей, семь вопросов FAQ — все они были заголовками.

## Статичный снапшот

`dist/index.html` (то, что видят краулеры без JS) — 1 × H1 + 9 × H2, ни одного H3/H4. Его набор H2 — сжатый конспект разделов, он не обязан совпадать один-в-один с живой страницей; бюджет выдержан в обоих документах.

## Замечание

Понижение части заголовков до обычного текста немного обедняет навигацию по разделам для скринридеров (переход «по заголовкам»). Разделы, на которые ведут пункты меню, заголовок сохранили; блоки-карточки и промо-строки — нет. Если захотите вернуть какому-то блоку H2 — это одна строка, но бюджет из тикета тогда сдвинется.

## Проверено

- `npx tsc --noEmit` — чисто; `npm run build` — зелёный.
- `npm test`: 5 новых тестов (`tests/issue-514-headings.test.mjs`) зелёные; 14 падений — ровно те же, что на `origin/main` (php, роуты, статьи БЗ, тема), к правке отношения не имеют.
- Живьём в браузере: FAQ, кейсы, промо-строка и карточки выглядят как раньше; счётчики заголовков сняты с реального DOM.
- Тест сторожит правило **«заголовок не печатается из данных цикла»** — чтобы карточки снова не начали плодить H3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)