### PR TITLE
fix(#551): безрасширенные адреса страниц → 301 на канонический .html

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -35,12 +35,30 @@ DirectoryIndex index.html
   RewriteCond %{HTTP:X-Forwarded-Proto} !https
   RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
-  # /privacy → /privacy.html (issue #542). Ссылка «обработку персональных
-  # данных» в галочке согласия под формами исторически вела на безрасширенный
-  # /privacy. Такого файла в вебруте нет, поэтому front controller ниже отдавал
-  # путь движку Интеграма, а тот читал «privacy» как имя базы и отвечал ошибкой
-  # вместо документа. Правило обязано стоять ВЫШЕ front controller.
-  RewriteRule ^privacy/?$ /privacy.html [R=301,L]
+  # Безрасширенные адреса страниц → канонический /<slug>.html (issues #542, #551).
+  #
+  # Билд кладёт в dist/ только `<slug>.html`. Маршруты в src/router.tsx объявлены
+  # в двух написаниях, но безрасширенный вариант живёт лишь при клиентской
+  # навигации внутри SPA: прямой заход или ссылка извне — это не файл и не
+  # директория, поэтому front controller ниже отдавал путь движку Интеграма, а
+  # тот читал первый сегмент как имя базы и отвечал «Invalid database» вместо
+  # страницы. Так были сломаны /privacy, /terms, /resheniya, /excel-to-app и все
+  # лендинги (#551); #542 закрыл этим приёмом только /privacy.
+  #
+  # Список ЯВНЫЙ и закрытый — универсальное правило «нет файла → отдать
+  # <path>.html» ставить нельзя: оно перехватит URL реальной базы с совпадающим
+  # именем и уронит её. Каждое имя ниже проверено на живом сервере — базы с
+  # таким именем нет. Директории (/knowledge-base/, /ad-images/) сюда не входят:
+  # они реально существуют в вебруте и работают сами.
+  #
+  # Полноту списка стережёт tests/issue-551-extensionless-urls.test.mjs: новая
+  # страница без правила здесь валит тест.
+  #
+  # Правило обязано стоять ВЫШЕ front controller, иначе путь снова уедет в
+  # index.php. `!-d` — страховка на случай, если такая директория когда-нибудь
+  # появится в вебруте: тогда выигрывает она, а не редирект.
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule ^(privacy|terms|resheniya|excel-to-app|agent-platforms|catalog-matching|konstruktor-prilozhenij|informatsionnaya-sistema|sravnenie-s-bitrix-amocrm|tokens|baza-zayavok|upravlenie-proektami|planirovanie-proizvodstva|skladskoy-uchet|upravlenie-zakupkami|finansovyy-uchet|kadrovyy-uchet|crm-uchet-klientov|uchet-dogovorov|upravlencheskiy-uchet|dvizhenie-tmc-i-ds)/?$ /$1.html [R=301,L]
 
   # Front controller: real files/dirs served as-is; everything else → index.php.
   RewriteCond %{REQUEST_FILENAME} !-f

--- a/tests/issue-542-privacy.test.mjs
+++ b/tests/issue-542-privacy.test.mjs
@@ -68,7 +68,13 @@ test('SPA знает маршрут политики в обоих написа�
 })
 
 test('.htaccess редиректит /privacy на /privacy.html ДО front controller (#542)', () => {
-  const redirect = htaccess.search(/^\s*RewriteRule\s+\^privacy\/\?\$\s+\/privacy\.html\s+\[R=301,L\]/m)
+  // С #551 правило собрано в одну альтернацию на все страницы сайта
+  // (`^(privacy|terms|…)/?$ → /$1.html`); полноту списка стережёт
+  // tests/issue-551-extensionless-urls.test.mjs. Здесь важно одно: /privacy
+  // канонизируется 301-м и делает это ВЫШЕ front controller.
+  const redirect = htaccess.search(
+    /^\s*RewriteRule\s+\^\((?:[^)]*\|)?privacy(?:\|[^)]*)?\)\/\?\$\s+\/\$1\.html\s+\[R=301,L\]/m,
+  )
   const frontController = htaccess.search(/^\s*RewriteRule\s+\^\s+index\.php/m)
 
   assert.notEqual(redirect, -1, 'правило редиректа /privacy → /privacy.html отсутствует')

--- a/tests/issue-551-extensionless-urls.test.mjs
+++ b/tests/issue-551-extensionless-urls.test.mjs
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { HUB, USE_CASES } from '../src/data/usecases.mjs'
+
+// Issue #551: ссылка «обработку персональных данных» под формой на
+// /excel-to-app.html вела на /privacy и не работала — «Починить здесь и во всех
+// других местах».
+//
+// Причина — не в React. Вебрут ideav.ru общий с движком Интеграма: front
+// controller в public/.htaccess шлёт всё, что не файл и не директория, в
+// index.php, а движок читает первый сегмент пути как имя базы. Билд кладёт в
+// dist/ только `<slug>.html`, поэтому ЛЮБОЙ безрасширенный адрес страницы
+// (/privacy, /terms, /resheniya, /excel-to-app, лендинги) отдавался движком с
+// «Invalid database». Маршруты в src/router.tsx объявлены в двух написаниях, но
+// безрасширенный вариант живёт лишь при клиентской навигации внутри SPA.
+//
+// #542 закрыл этим приёмом одну страницу — /privacy. Тест держит инвариант для
+// ВСЕХ: у каждой верхнеуровневой страницы сайта есть 301 с безрасширенного
+// адреса на канонический `.html`, и стоит он ВЫШЕ front controller.
+
+const repo = new URL('..', import.meta.url).pathname
+const htaccess = readFileSync(resolve(repo, 'public/.htaccess'), 'utf8')
+const router = readFileSync(resolve(repo, 'src/router.tsx'), 'utf8')
+
+/**
+ * Страницы, которые в вебруте существуют ДИРЕКТОРИЕЙ (пререндер кладёт базу
+ * знаний как `knowledge-base/index.html`, `ad-images` — статическая папка из
+ * public/). Безрасширенный адрес у них и так работает: Apache сам редиректит на
+ * `<slug>/`. Правило для них не нужно и вредно — оно увело бы запрос с
+ * работающей директории на несуществующий файл.
+ */
+const SERVED_AS_DIRECTORY = new Set(['knowledge-base', 'ad-images'])
+
+/**
+ * Маршруты SPA без статического снапшота: билд не кладёт в dist/ ни
+ * `success.html`, ни `fail.html`, и ни одна ссылка в проекте на них не ведёт —
+ * это осиротевшие маршруты. Редирект `/success → /success.html` вёл бы с одного
+ * несуществующего адреса на другой, поэтому их тут нет. Появится снапшот и
+ * ссылки — убрать отсюда и добавить в правило.
+ */
+const NO_STATIC_SNAPSHOT = new Set(['success', 'fail'])
+
+/** Верхнеуровневые `<slug>.html` маршруты SPA — источник истины по страницам. */
+function routerPageSlugs() {
+  const slugs = new Set()
+  for (const [, path] of router.matchAll(/path: '([^']+)'/g)) {
+    if (!path.endsWith('.html')) continue
+    const slug = path.slice(0, -'.html'.length)
+    if (slug.includes('/') || slug.includes(':')) continue // вложенные маршруты
+    slugs.add(slug)
+  }
+  return slugs
+}
+
+/** Полный список страниц: явные маршруты + 11 лендингов из usecases.mjs. */
+function expectedSlugs() {
+  const slugs = routerPageSlugs()
+  for (const useCase of USE_CASES) slugs.add(useCase.slug)
+  for (const slug of [...SERVED_AS_DIRECTORY, ...NO_STATIC_SNAPSHOT]) slugs.delete(slug)
+  return [...slugs].sort()
+}
+
+/** Рекурсивный обход исходников — ищем ссылки во всём коде, а не в списке файлов. */
+function listSourceFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...listSourceFiles(full))
+    else if (/\.(tsx?|mjs)$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Слаги, для которых билд реально пишет `dist/<slug>.html`. Читаем это из самих
+ * пререндеров, а не из собранного dist/: каталог сборки принадлежит билду и
+ * тесты его не трогают (#520).
+ */
+function prerenderedSlugs() {
+  const slugs = new Set()
+  const dir = resolve(repo, 'scripts')
+
+  for (const file of readdirSync(dir)) {
+    if (!file.startsWith('prerender-') || !file.endsWith('.mjs')) continue
+    const src = readFileSync(resolve(dir, file), 'utf8')
+    // `resolve(dist, 'privacy.html')` и `dist/privacy.html` в логах пререндера.
+    for (const [, slug] of src.matchAll(/dist[/,]\s*'?([a-z0-9-]+)\.html/g)) slugs.add(slug)
+  }
+
+  // prerender-usecases пишет 11 лендингов и хаб по шаблону `${slug}.html` —
+  // литералов в коде нет, слаги приходят из данных.
+  for (const useCase of USE_CASES) slugs.add(useCase.slug)
+  slugs.add(HUB.slug)
+
+  return slugs
+}
+
+/** Позиция строки front controller — всё, что чинит роутинг, обязано быть выше. */
+const frontController = htaccess.search(/^\s*RewriteRule\s+\^\s+index\.php/m)
+
+/** Правило-альтернация: `RewriteRule ^(a|b|c)/?$ /$1.html [R=301,L]`. */
+const REDIRECT_RULE = /^\s*RewriteRule\s+\^\(([^)]*)\)\/\?\$\s+\/\$1\.html\s+\[([^\]]+)\]/m
+
+test('front controller на месте — без него ложатся все базы (#422/#423)', () => {
+  assert.notEqual(frontController, -1, 'RewriteRule ^ index.php обязан остаться в .htaccess')
+})
+
+test('у каждой страницы есть 301 с безрасширенного адреса на канонический .html (#551)', () => {
+  const slugs = expectedSlugs()
+  assert.ok(slugs.length >= 20, `ожидали список страниц, получили ${slugs.length}`)
+
+  const rule = htaccess.match(REDIRECT_RULE)
+  const listed = new Set(rule ? rule[1].split('|') : [])
+
+  for (const slug of slugs) {
+    // Правило может быть как одной альтернацией на все слаги, так и расписанным
+    // по одному — принимаем оба написания.
+    const standalone = new RegExp(`^\\s*RewriteRule\\s+\\^${slug}/\\?\\$\\s+/${slug}\\.html`, 'm')
+
+    assert.ok(
+      listed.has(slug) || standalone.test(htaccess),
+      `в public/.htaccess нет редиректа /${slug} → /${slug}.html — безрасширенный адрес ` +
+        `уйдёт во front controller и движок ответит «Invalid database» (#551)`,
+    )
+  }
+})
+
+test('редирект стоит ВЫШЕ front controller, иначе путь снова уедет в index.php', () => {
+  const redirect = htaccess.search(REDIRECT_RULE)
+  assert.notEqual(redirect, -1, 'правило extensionless-редиректа не найдено')
+  assert.ok(redirect < frontController, 'правило обязано стоять до RewriteRule ^ index.php')
+})
+
+test('редиректы отдают 301 и обрывают цепочку правил', () => {
+  const rule = htaccess.match(REDIRECT_RULE)
+  assert.ok(rule, 'правило extensionless-редиректа не найдено')
+  assert.match(rule[2], /R=301/, 'канонизация адреса — постоянный редирект, иначе он не склеит сигналы для поиска')
+  assert.match(rule[2], /\bL\b/, 'без [L] запрос продолжит обработку и уедет во front controller')
+})
+
+test('универсального правила «нет файла → отдать <path>.html» нет — оно уронило бы базу-тёзку', () => {
+  // Такое правило перехватывает URL реальной базы, если её имя совпадёт с именем
+  // любого .html в вебруте. Список обязан оставаться закрытым и явным.
+  const rule = htaccess.match(REDIRECT_RULE)
+  assert.ok(rule, 'правило extensionless-редиректа не найдено')
+  assert.doesNotMatch(
+    rule[1],
+    /[.*+\][]/,
+    `паттерн редиректа стал обобщённым («${rule[1]}») — он перехватит URL реальной базы с совпадающим именем (#551)`,
+  )
+})
+
+test('каждая цель редиректа — страница, которую билд действительно создаёт', () => {
+  // Редирект на несуществующий `<slug>.html` бесполезен: файла нет → front
+  // controller → тот же «Invalid database», только хопом дальше. Так в список
+  // едва не уехали success/fail — маршруты SPA, для которых снапшот не пишется.
+  //
+  // Источник истины — сами пререндеры (dist/ репозитория тесты не трогают, #520).
+  const rule = htaccess.match(REDIRECT_RULE)
+  assert.ok(rule, 'правило extensionless-редиректа не найдено')
+
+  for (const slug of rule[1].split('|')) {
+    assert.ok(
+      prerenderedSlugs().has(slug),
+      `редирект ведёт на /${slug}.html, но ни один scripts/prerender-*.mjs такой страницы ` +
+        `не пишет — запрос уйдёт во front controller и движок ответит «Invalid database» (#551)`,
+    )
+  }
+})
+
+test('директории из вебрута не перехвачены редиректом (/knowledge-base/, /ad-images/)', () => {
+  const rule = htaccess.match(REDIRECT_RULE)
+  const listed = new Set(rule ? rule[1].split('|') : [])
+
+  for (const dir of SERVED_AS_DIRECTORY) {
+    assert.ok(
+      !listed.has(dir),
+      `/${dir} существует директорией и работает сам — редирект на /${dir}.html увёл бы его в никуда`,
+    )
+  }
+})
+
+test('ссылки в коде ведут на канонический .html, а не на безрасширенный адрес', () => {
+  // Первопричина #551: в коде осталась ссылка href="/privacy". Ловим весь класс,
+  // а не одну страницу.
+  const slugs = expectedSlugs()
+  const files = ['src', 'scripts'].flatMap(dir => listSourceFiles(resolve(repo, dir)))
+
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8')
+    for (const slug of slugs) {
+      assert.doesNotMatch(
+        src,
+        new RegExp(`(href|to)="/${slug}"`),
+        `${file.slice(repo.length)}: ссылка на /${slug} без .html — канонический адрес /${slug}.html (#551)`,
+      )
+    }
+  }
+})


### PR DESCRIPTION
Закрывает #551.

## Что не так

Ссылка «обработку персональных данных» под формой на https://ideav.ru/excel-to-app.html#excel-form ведёт на `/privacy` и открывает ошибку движка.

Первопричина — **не в React**. Вебрут ideav.ru общий с движком Интеграма: front controller в `public/.htaccess` шлёт всё, что не файл и не директория, в `index.php`, а движок читает первый сегмент пути как имя базы. Билд кладёт в `dist/` только `<slug>.html`. Маршруты в `src/router.tsx` объявлены в двух написаниях, но безрасширенный вариант живёт **лишь при клиентской навигации внутри SPA** — прямой заход или внешняя ссылка уходит в движок.

#542 чинил ровно это, но одним точечным правилом на одну страницу. Класс бага остался. Замер живого сайта **до** правки:

| адрес | было |
|---|---|
| `/privacy`, `/terms`, `/resheniya`, `/tokens` | 302 → `start.html?db=…&r=dBNotExists` |
| `/excel-to-app`, `/agent-platforms`, `/catalog-matching`, `/konstruktor-prilozhenij`, `/informatsionnaya-sistema`, `/sravnenie-s-bitrix-amocrm` | `Invalid database` |
| все 11 лендингов (`/baza-zayavok`, `/finansovyy-uchet`, …) | `Invalid database` |

## Что сделано

Одно правило-альтернация на 22 страницы, **выше** front controller:

```apache
RewriteCond %{REQUEST_FILENAME} !-d
RewriteRule ^(privacy|terms|resheniya|excel-to-app|…)/?$ /$1.html [R=301,L]
```

Список **явный и закрытый**. Универсальное «нет файла → отдать `<path>.html`» ставить нельзя: оно перехватит URL реальной базы с совпадающим именем и уронит её. Каждое из 22 имён проверено на живом сервере — базы с таким именем нет.

Не входят в список:
- **`/knowledge-base`, `/ad-images`** — существуют в вебруте директориями, Apache сам редиректит на `<slug>/`; правило увело бы их на несуществующий файл;
- **`/success`, `/fail`** — осиротевшие маршруты SPA: снапшот для них не пишется и ни одна ссылка в проекте на них не ведёт, редирект вёл бы с одного мёртвого адреса на другой. (Замечено самим тестом — они прошли в список с первой попытки и были выброшены. `/success.html` и `/fail.html` на живом сайте тоже отдают `Invalid database`; отдельный вопрос, нужны ли эти страницы вообще.)

## Проверено

**На настоящем Apache** (docker `php:8.2-apache`, вебрут = собранный `dist/` + заглушка `index.php`, как на проде):

- все 22 безрасширенных адреса → **один 301-хоп** на `<slug>.html` → 200 с правильным `<title>`, движок не участвует;
- `/asmoseo/table/42`, `/asmoseo`, `/mydb/query/7`, `/crm` → **доходят до движка** (#422/#423 не сломан);
- `/privacy/table/42`, `/terms/anything` → **тоже доходят до движка**: правило якорится на `$`, поэтому база с именем `privacy` продолжила бы работать;
- `/knowledge-base/`, `/ad-images/`, `/` — поведение не изменилось.

**Тесты.** Новый `tests/issue-551-extensionless-urls.test.mjs` держит инвариант целиком: полнота списка (слаги выводятся из `router.tsx` + `usecases.mjs` — новая страница без правила валит тест), позиция выше front controller, `R=301` + `L`, отсутствие generic-правила, живая цель у каждого редиректа (сверка с `scripts/prerender-*.mjs`, `dist/` репозитория не трогаем — #520) и запрет безрасширенных ссылок в коде.

Тест проверен мутациями: убрать слаг из правила → падает; добавить generic-правило → падает; вписать `success` → падает.

`tests/issue-542-privacy.test.mjs` обновлён под новую форму правила, смысл проверки сохранён.

`npm run build` зелёный, `verify-htaccess` зелёный. `npm test`: 13 провалов — все предсуществующие, `comm` с прогоном на `origin/main` показывает **ноль новых**.

## ⚠️ Само по себе это issue не закроет — нужен деплой

На живом сайте сейчас **сборка старше #543**: в задеплоенном бандле всё ещё `href="/privacy"`, а `/privacy.html` отдаёт `Invalid database` — файла на сервере нет. То есть починка #542 в прод не уезжала. Пока не пройдёт выкладка `dist/`, ссылка из #551 останется битой независимо от этого PR.

Деплой overlay-ом, **без `rsync --delete`** (в том же вебруте лежит платформа из ideav/crm), с бэкапом `.htaccess`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)