### PR TITLE
feat(#553): персональная страница с контактами — /alexey-semenov.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "test": "node --test tests/*.test.mjs",
-    "build": "node scripts/generate-blog-posts.mjs && node scripts/generate-og-images.mjs && node scripts/sync-kb-sitemap.mjs && vite build && node scripts/prerender-knowledge-base.mjs && node scripts/prerender-excel-to-app.mjs && node scripts/prerender-agent-platforms.mjs && node scripts/prerender-catalog-matching.mjs && node scripts/prerender-information-system.mjs && node scripts/prerender-sravnenie.mjs && node scripts/prerender-konstruktor-prilozhenij.mjs && node scripts/prerender-usecases.mjs && node scripts/prerender-tokens.mjs && node scripts/prerender-privacy.mjs && node scripts/prerender-terms.mjs && node scripts/prerender-landing.mjs && node scripts/verify-htaccess.mjs",
+    "build": "node scripts/generate-blog-posts.mjs && node scripts/generate-og-images.mjs && node scripts/sync-kb-sitemap.mjs && vite build && node scripts/prerender-knowledge-base.mjs && node scripts/prerender-excel-to-app.mjs && node scripts/prerender-agent-platforms.mjs && node scripts/prerender-catalog-matching.mjs && node scripts/prerender-information-system.mjs && node scripts/prerender-sravnenie.mjs && node scripts/prerender-konstruktor-prilozhenij.mjs && node scripts/prerender-usecases.mjs && node scripts/prerender-tokens.mjs && node scripts/prerender-alexey-semenov.mjs && node scripts/prerender-privacy.mjs && node scripts/prerender-terms.mjs && node scripts/prerender-landing.mjs && node scripts/verify-htaccess.mjs",
     "dev:en": "vite --config site-en/vite.config.ts",
     "build:en": "vite build --config site-en/vite.config.ts",
     "og-images": "node scripts/generate-og-images.mjs",

--- a/scripts/prerender-alexey-semenov.mjs
+++ b/scripts/prerender-alexey-semenov.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Post-build prerender персональной страницы `/alexey-semenov.html`
+ * (SPA-роут, компонент src/pages/AlexeySemenov.tsx) — issue #553.
+ *
+ * Без этого шага страница отдаётся SPA-фолбэком (голый dist/index.html), и по
+ * ссылке из профиля Хабра и краулер, и человек с отключённым JS увидят ГЛАВНУЮ:
+ * её <title> и её содержимое (issue #418). Для ссылки, которая ставится в профиль
+ * вместо лендинга, это ровно то, чего быть не должно.
+ *
+ * Пишет sibling dist/alexey-semenov.html из чистого dist/index.html: свой <title>,
+ * description, canonical, Open Graph и JSON-LD `Person` + статический снимок в
+ * #root. React при загрузке заменяет #root живым SPA — снимок живёт только в
+ * HTTP-ответе для краулера.
+ *
+ * Запускать ПОСЛЕ prerender-knowledge-base.mjs и ДО prerender-landing.mjs:
+ * landing перезаписывает dist/index.html последним, вставляя свой #lp-prerender.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = resolve(__dirname, '..')
+const dist = resolve(root, 'dist')
+const SITE = 'https://ideav.ru'
+const PUBLISHER = 'Интеграм'
+const PATH = '/alexey-semenov.html'
+
+const PERSON = 'Алексей Семёнов'
+const ROLE = 'Основатель Интеграма'
+const TELEGRAM = 'qdmadept'
+const EMAIL = 'abc@integram.io'
+const PHONE_HREF = '+79955060167'
+const PHONE_TEXT = '+7 (995) 506-01-67'
+
+function escape(s) {
+  return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Статический снимок — зеркалит src/pages/AlexeySemenov.tsx.
+//  Ни цен, ни услуг, ни призывов: страница персональная, и это её смысл (#553).
+// ───────────────────────────────────────────────────────────────────────────
+const bodyHtml = `
+<article id="as-prerender">
+  <p class="as-prerender__eyebrow">Персональная страница</p>
+  <h1>${escape(PERSON)}</h1>
+  <p class="as-prerender__lead">${escape(ROLE)} — конструктора, в котором бизнес-приложение собирается из описания задачи.</p>
+  <p>Занимаюсь платформой и тем, что вокруг неё: разбираю задачи из практики, меряю, что получается, и пишу об этом — включая случаи, когда получается не так, как задумывалось.</p>
+  <p>Пишу и отвечаю сам. Если у вас вопрос по платформе, задача или замечание — напишите любым удобным способом.</p>
+  <h2>Контакты</h2>
+  <ul class="as-prerender__contacts">
+    <li><a href="https://t.me/${escape(TELEGRAM)}" rel="me">@${escape(TELEGRAM)}</a> — Telegram</li>
+    <li><a href="mailto:${escape(EMAIL)}">${escape(EMAIL)}</a> — почта</li>
+    <li><a href="tel:${escape(PHONE_HREF)}">${escape(PHONE_TEXT)}</a> — телефон</li>
+  </ul>
+  <footer class="as-prerender__footer">
+    <p>АО «Интеграм», ИНН 9716002710, ОГРН 1247700757590.</p>
+  </footer>
+</article>
+<style>
+  #as-prerender { max-width: 42rem; margin: 0 auto; padding: 4rem 1rem 2rem;
+    font-family: ui-sans-serif, system-ui, sans-serif; color: #1e293b; }
+  #as-prerender h1 { font-size: 2.4rem; line-height: 1.1; margin: 0.5rem 0 1rem; }
+  #as-prerender h2 { font-size: 1.35rem; margin: 2.25rem 0 0.5rem; }
+  #as-prerender p  { line-height: 1.6; margin: 0.5rem 0; }
+  #as-prerender .as-prerender__eyebrow { text-transform: uppercase; letter-spacing: 0.1em;
+    font-size: 0.72rem; color: #3b82f6; font-weight: 700; margin: 0; }
+  #as-prerender .as-prerender__lead { font-size: 1.1rem; color: #475569; }
+  #as-prerender .as-prerender__contacts { line-height: 1.9; margin: 0.5rem 0; padding-left: 1.2rem; }
+  #as-prerender .as-prerender__footer { margin-top: 3rem; padding-top: 1.5rem;
+    border-top: 1px solid #e2e8f0; font-size: 0.88rem; color: #64748b; }
+  /* Тёмная тема — по классу .dark на <html> (его ставит синхронный скрипт в <head>
+     из localStorage), а НЕ по prefers-color-scheme: так же, как на прочих страницах. */
+  .dark #as-prerender { color: #e2e8f0; }
+  .dark #as-prerender .as-prerender__lead, .dark #as-prerender .as-prerender__footer { color: #94a3b8; }
+</style>`
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Разметка данных: Person + ProfilePage. Именно её ждёт площадка, проверяющая
+//  «персональный сайт с контактами», и поисковик — от страницы про человека.
+// ───────────────────────────────────────────────────────────────────────────
+const canonical = `${SITE}${PATH}`
+// Тексты пишем ЯВНО, а не собираем из PERSON/ROLE: склонение по-русски механически не выводится
+// («страница Алексей Семёнов» вместо «Алексея Семёнова»), а toLowerCase() портит бренд
+// («основатель интеграма»). Оба дефекта были в первой сборке этой страницы.
+const seoTitle = 'Алексей Семёнов — контакты'
+const ogTitle = 'Алексей Семёнов — основатель Интеграма'
+const ogDescription =
+  'Персональная страница Алексея Семёнова: чем занимаюсь и как со мной связаться — Telegram, почта, телефон.'
+const metaDescription =
+  'Персональная страница Алексея Семёнова, основателя Интеграма. Контакты для связи: Telegram, почта, телефон.'
+const ogImage = `${SITE}/og/home.png`
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'ProfilePage',
+      '@id': `${canonical}#webpage`,
+      url: canonical,
+      name: seoTitle,
+      description: ogDescription,
+      inLanguage: 'ru',
+      isPartOf: { '@id': `${SITE}/#website` },
+      mainEntity: { '@id': `${canonical}#person` },
+    },
+    {
+      '@type': 'Person',
+      '@id': `${canonical}#person`,
+      name: PERSON,
+      jobTitle: ROLE,
+      url: canonical,
+      email: `mailto:${EMAIL}`,
+      telephone: PHONE_HREF,
+      sameAs: [`https://t.me/${TELEGRAM}`],
+      worksFor: { '@type': 'Organization', name: PUBLISHER, url: `${SITE}/` },
+    },
+  ],
+}
+
+const headTags = [
+  `<link rel="canonical" href="${escape(canonical)}" />`,
+  `<meta property="og:type" content="profile" />`,
+  `<meta property="og:url" content="${escape(canonical)}" />`,
+  `<meta property="og:title" content="${escape(ogTitle)}" />`,
+  `<meta property="og:description" content="${escape(ogDescription)}" />`,
+  `<meta property="og:image" content="${escape(ogImage)}" />`,
+  `<meta property="og:image:width" content="1200" />`,
+  `<meta property="og:image:height" content="630" />`,
+  `<meta property="og:locale" content="ru_RU" />`,
+  `<meta property="og:site_name" content="${PUBLISHER}" />`,
+  `<meta name="twitter:card" content="summary_large_image" />`,
+  `<meta name="twitter:title" content="${escape(ogTitle)}" />`,
+  `<meta name="twitter:description" content="${escape(ogDescription)}" />`,
+  `<meta name="twitter:image" content="${escape(ogImage)}" />`,
+  `<script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>`,
+].join('\n    ')
+
+// ───────────────────────────────────────────────────────────────────────────
+//  Пишем dist/alexey-semenov.html из чистой оболочки SPA
+// ───────────────────────────────────────────────────────────────────────────
+const indexPath = resolve(dist, 'index.html')
+const source = readFileSync(indexPath, 'utf8')
+
+if (source.includes('id="lp-prerender"')) {
+  console.error(
+    '✗ prerender-alexey-semenov: dist/index.html уже несёт снимок главной — запускать ДО prerender-landing.mjs',
+  )
+  process.exit(1)
+}
+if (!source.includes('<div id="root"></div>')) {
+  console.error('✗ prerender-alexey-semenov: <div id="root"></div> не найден в dist/index.html')
+  process.exit(1)
+}
+
+const html = source
+  .replace(/<title>[\s\S]*?<\/title>/, `<title>${escape(seoTitle)}</title>`)
+  .replace(
+    /<meta name="description"[^>]*>/,
+    `<meta name="description" content="${escape(metaDescription)}" />`,
+  )
+  .replace('</head>', `    ${headTags}\n  </head>`)
+  .replace('<div id="root"></div>', `<div id="root">${bodyHtml}</div>`)
+
+const outPath = resolve(dist, 'alexey-semenov.html')
+writeFileSync(outPath, html)
+console.log(`✓ personal page prerendered → dist/alexey-semenov.html (${html.length} bytes)`)

--- a/src/pages/AlexeySemenov.tsx
+++ b/src/pages/AlexeySemenov.tsx
@@ -1,0 +1,87 @@
+import { Mail, Phone, Send } from 'lucide-react'
+
+/**
+ * Персональная страница с контактами (issue #553).
+ *
+ * Зачем именно так. Поддержка Хабра требует, чтобы в профиле стояла ссылка на
+ * ПЕРСОНАЛЬНУЮ страницу с контактами, а не на лендинг с услугами. Поэтому здесь
+ * нет ни цен, ни призывов купить, ни перечня услуг — только кто это, чем занят и
+ * как связаться. Всё, что похоже на продажу, ломает смысл страницы.
+ *
+ * Тон — скромный (прямая просьба в тикете). Никаких «эксперт с N-летним опытом»:
+ * страница обязана быть проверяемой, а не рекламной.
+ */
+
+const TELEGRAM = 'qdmadept'
+const EMAIL = 'abc@integram.io'
+const PHONE_HREF = '+79955060167'
+const PHONE_TEXT = '+7 (995) 506-01-67'
+
+export default function AlexeySemenov() {
+  return (
+    <div className="overflow-hidden">
+      <section className="py-24">
+        <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
+          <p className="text-xs font-black uppercase tracking-widest text-blue-500 mb-3">
+            Персональная страница
+          </p>
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Алексей Семёнов</h1>
+          <p className="text-lg text-slate-600 dark:text-slate-300 mb-10">
+            Основатель Интеграма — конструктора, в котором бизнес-приложение собирается
+            из описания задачи.
+          </p>
+
+          <div className="space-y-4 text-slate-600 dark:text-slate-300 leading-relaxed">
+            <p>
+              Занимаюсь платформой и тем, что вокруг неё: разбираю задачи из практики,
+              меряю, что получается, и пишу об этом — включая случаи, когда получается не так,
+              как задумывалось.
+            </p>
+            <p>
+              Пишу и отвечаю сам. Если у вас вопрос по платформе, задача или замечание —
+              напишите любым удобным способом.
+            </p>
+          </div>
+
+          <h2 className="text-xl font-bold mt-12 mb-4">Контакты</h2>
+          <ul className="space-y-3">
+            <li>
+              <a
+                href={`https://t.me/${TELEGRAM}`}
+                className="inline-flex items-center gap-2 text-slate-700 dark:text-slate-200 hover:text-blue-500 transition-colors"
+              >
+                <Send className="w-4 h-4 shrink-0" aria-hidden="true" />
+                <span className="font-semibold">@{TELEGRAM}</span>
+                <span className="text-slate-400 dark:text-slate-500">— Telegram</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href={`mailto:${EMAIL}`}
+                className="inline-flex items-center gap-2 text-slate-700 dark:text-slate-200 hover:text-blue-500 transition-colors"
+              >
+                <Mail className="w-4 h-4 shrink-0" aria-hidden="true" />
+                <span className="font-semibold">{EMAIL}</span>
+                <span className="text-slate-400 dark:text-slate-500">— почта</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href={`tel:${PHONE_HREF}`}
+                className="inline-flex items-center gap-2 text-slate-700 dark:text-slate-200 hover:text-blue-500 transition-colors"
+              >
+                <Phone className="w-4 h-4 shrink-0" aria-hidden="true" />
+                <span className="font-semibold">{PHONE_TEXT}</span>
+                <span className="text-slate-400 dark:text-slate-500">— телефон</span>
+              </a>
+            </li>
+          </ul>
+
+          <p className="mt-12 pt-6 border-t border-slate-200 dark:border-slate-800 text-sm text-slate-400 dark:text-slate-500">
+            АО «Интеграм», ИНН 9716002710, ОГРН 1247700757590.
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,6 +17,8 @@ const ExcelConstructor = lazy(() => import('./pages/ExcelConstructor'))
 const InformationSystem = lazy(() => import('./pages/InformationSystem'))
 const BitrixAmoComparison = lazy(() => import('./pages/BitrixAmoComparison'))
 const Tokens = lazy(() => import('./pages/Tokens'))
+// #553: персональная страница с контактами (требование поддержки Хабра к профилю).
+const AlexeySemenov = lazy(() => import('./pages/AlexeySemenov'))
 const AdImages = lazy(() => import('./pages/AdImages'))
 const KnowledgeBase = lazy(() => import('./pages/KnowledgeBase'))
 const KnowledgeBaseArticle = lazy(() => import('./pages/KnowledgeBaseArticle'))
@@ -89,6 +91,10 @@ export const router = createBrowserRouter([
       {
         path: 'tokens.html',
         element: <Tokens />,
+      },
+      {
+        path: 'alexey-semenov.html',
+        element: <AlexeySemenov />,
       },
       {
         path: 'ad-images.html',

--- a/tests/prerender-alexey-semenov.test.mjs
+++ b/tests/prerender-alexey-semenov.test.mjs
@@ -1,0 +1,139 @@
+/**
+ * Issue #553 — персональная страница с контактами `/alexey-semenov.html`.
+ *
+ * Страница заводится не ради SEO, а ради конкретного требования площадки: в профиле
+ * должна стоять ссылка на ПЕРСОНАЛЬНУЮ страницу с контактами, а не на лендинг с
+ * услугами. Отсюда и проверки: страница обязана открываться сама по себе (не
+ * SPA-фолбэком главной), нести имя, контакты и разметку Person — и НЕ нести
+ * признаков лендинга (цены, тарифы, «купить»).
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, cpSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+const repo = new URL('..', import.meta.url).pathname
+const scriptSrc = readFileSync(resolve(repo, 'scripts/prerender-alexey-semenov.mjs'), 'utf8')
+const pageSrc = readFileSync(resolve(repo, 'src/pages/AlexeySemenov.tsx'), 'utf8')
+const indexHtml = readFileSync(resolve(repo, 'index.html'), 'utf8')
+const landingScript = resolve(repo, 'scripts/prerender-landing.mjs')
+
+const homeTitle = indexHtml.match(/<title>([\s\S]*?)<\/title>/)[1]
+
+function makeWorkspace(prefix) {
+  const work = mkdtempSync(resolve(tmpdir(), prefix))
+  mkdirSync(resolve(work, 'dist'), { recursive: true })
+  mkdirSync(resolve(work, 'scripts'), { recursive: true })
+  cpSync(
+    resolve(repo, 'scripts/prerender-alexey-semenov.mjs'),
+    resolve(work, 'scripts/prerender-alexey-semenov.mjs'),
+  )
+  cpSync(landingScript, resolve(work, 'scripts/prerender-landing.mjs'))
+  // Пререндер главной читает src/data (usecases + FAQ) — без них песочница падает (#495).
+  cpSync(resolve(repo, 'src/data'), resolve(work, 'src/data'), { recursive: true })
+  writeFileSync(resolve(work, 'dist/index.html'), indexHtml)
+  return work
+}
+
+test('build pipeline runs the personal-page prerender after the KB one and before the landing one', () => {
+  const build = JSON.parse(readFileSync(resolve(repo, 'package.json'), 'utf8')).scripts.build
+  assert.match(build, /prerender-alexey-semenov\.mjs/)
+  assert.ok(
+    build.indexOf('prerender-knowledge-base.mjs') < build.indexOf('prerender-alexey-semenov.mjs'),
+    'personal page prerender must run after the knowledge base prerender',
+  )
+  assert.ok(
+    build.indexOf('prerender-alexey-semenov.mjs') < build.indexOf('prerender-landing.mjs'),
+    'personal page prerender must run before the landing prerender (clean index.html template)',
+  )
+})
+
+test('the SPA route exists — without it the .html file and the app would disagree', () => {
+  const router = readFileSync(resolve(repo, 'src/router.tsx'), 'utf8')
+  assert.match(router, /alexey-semenov\.html/)
+  assert.match(router, /AlexeySemenov/)
+})
+
+test('prerender writes a crawlable dist/alexey-semenov.html with its own, non-home title', () => {
+  const work = makeWorkspace('personal-prerender-')
+  execFileSync('node', ['scripts/prerender-alexey-semenov.mjs'], { cwd: work })
+
+  const outPath = resolve(work, 'dist/alexey-semenov.html')
+  assert.ok(existsSync(outPath), 'dist/alexey-semenov.html must be created')
+  const out = readFileSync(outPath, 'utf8')
+
+  assert.doesNotMatch(out, /<div id="root"><\/div>/, '#root must not be left empty')
+  assert.match(out, /<div id="root">\s*<article id="as-prerender"/)
+  assert.match(out, /<h1[^>]*>Алексей Семёнов<\/h1>/)
+
+  const title = out.match(/<title>([\s\S]*?)<\/title>/)[1]
+  assert.notEqual(title, homeTitle, 'the personal page must not reuse the home page title')
+  assert.match(title, /Алексей Семёнов/)
+  assert.ok(title.length <= 60, `title should be <= 60 chars, got ${title.length}`)
+
+  const desc = out.match(/<meta name="description" content="([\s\S]*?)"/)[1]
+  assert.ok(desc.length <= 158, `description should be <= 158 chars, got ${desc.length}`)
+
+  assert.match(out, /<link rel="canonical" href="https:\/\/ideav\.ru\/alexey-semenov\.html" \/>/)
+  assert.match(out, /<meta property="og:type" content="profile" \/>/)
+})
+
+test('the page carries the contacts — that is the whole reason it exists (#553)', () => {
+  const work = makeWorkspace('personal-prerender-contacts-')
+  execFileSync('node', ['scripts/prerender-alexey-semenov.mjs'], { cwd: work })
+  const out = readFileSync(resolve(work, 'dist/alexey-semenov.html'), 'utf8')
+
+  assert.match(out, /href="https:\/\/t\.me\/qdmadept"/, 'Telegram contact must be present')
+  assert.match(out, /href="mailto:abc@integram\.io"/, 'email contact must be present')
+  assert.match(out, /href="tel:\+79955060167"/, 'phone contact must be present')
+
+  // Разметка Person — ею площадка и поисковик отличают персональную страницу от лендинга.
+  assert.match(out, /"@type":"Person"/)
+  assert.match(out, /"name":"Алексей Семёнов"/)
+  assert.match(out, /"@type":"ProfilePage"/)
+
+  // Те же контакты обязаны быть и в React-версии страницы, иначе снимок и приложение разойдутся.
+  assert.match(pageSrc, /qdmadept/)
+  assert.match(pageSrc, /abc@integram\.io/)
+  assert.match(pageSrc, /\+79955060167/)
+})
+
+test('the page is personal, not a landing: no prices, tariffs or buy-now calls (#553)', () => {
+  const work = makeWorkspace('personal-prerender-tone-')
+  execFileSync('node', ['scripts/prerender-alexey-semenov.mjs'], { cwd: work })
+  const snapshot = readFileSync(resolve(work, 'dist/alexey-semenov.html'), 'utf8')
+    .match(/<article id="as-prerender">[\s\S]*?<\/article>/)[0]
+
+  // Комментарии из проверки убираем: они ОПИСЫВАЮТ запрет («ни призывов купить»), и без
+  // вычистки тест ловил бы собственную формулировку правила вместо текста страницы.
+  const pageVisible = pageSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+  for (const banned of [/тариф/i, /\bцен[аыу]\b/i, /купить/i, /оставить заявку/i, /руб/i, /₽/]) {
+    assert.doesNotMatch(snapshot, banned, `personal page must not read as a sales landing: ${banned}`)
+    assert.doesNotMatch(pageVisible, banned, `personal page must not read as a sales landing: ${banned}`)
+  }
+})
+
+test('prerender does not mutate dist/index.html (home page)', () => {
+  const work = makeWorkspace('personal-prerender-home-')
+  const before = readFileSync(resolve(work, 'dist/index.html'), 'utf8')
+  execFileSync('node', ['scripts/prerender-alexey-semenov.mjs'], { cwd: work })
+  const after = readFileSync(resolve(work, 'dist/index.html'), 'utf8')
+  assert.equal(before, after, 'the home page shell must stay untouched')
+})
+
+test('prerender refuses to run after the landing prerender patched index.html', () => {
+  const work = makeWorkspace('personal-prerender-order-')
+  execFileSync('node', ['scripts/prerender-landing.mjs'], { cwd: work })
+  assert.throws(
+    () => execFileSync('node', ['scripts/prerender-alexey-semenov.mjs'], { cwd: work, stdio: 'pipe' }),
+    /Command failed/,
+    'running after the landing prerender must fail loudly',
+  )
+})
+
+test('script documents its required position in the build pipeline', () => {
+  assert.match(scriptSrc, /ПОСЛЕ prerender-knowledge-base\.mjs и ДО prerender-landing\.mjs/)
+})


### PR DESCRIPTION
Closes #553.

## Что и почему именно так

Поддержка Хабра написала: в профиле должна быть **ссылка на персональный сайт с контактами**, а не на лендинги с услугами. Такой страницы на ideav.ru не было — добавил.

Страница ровно одна, вокруг ничего не тронуто: ни главная, ни футер, ни другие разделы, ни sitemap. Ссылки на неё ставятся отдельно и позже.

**Адрес:** `/alexey-semenov.html` — именной, чтобы по ссылке было сразу видно, что это страница человека, а не раздел продукта.

## Содержание

Тон скромный (прямая просьба в тикете): имя, чем занимаюсь в двух абзацах, контакты и реквизиты юрлица мелким шрифтом.

- Telegram [@qdmadept](https://t.me/qdmadept), почта abc@integram.io, телефон +7 (995) 506-01-67 — те же контакты, что уже опубликованы на сайте;
- **ни цен, ни тарифов, ни «купить», ни формы заявки** — всё, что читается как продажа, ломает ровно тот смысл, ради которого страница заводится;
- никаких биографических утверждений, которые нельзя проверить («эксперт с N-летним опытом» и подобного нет).

Имя и роль взяты из уже опубликованного в этом же репозитории (статья базы знаний про Pure Business Design), реквизиты — из `src/data/privacy.mjs`.

## Почему нужен пререндер

Без своего prerender-скрипта `/alexey-semenov.html` отдаётся SPA-фолбэком — голым `dist/index.html`, и краулер (а также человек с отключённым JS) по ссылке из профиля увидит **главную** с её заголовком (#418). Для ссылки, которая ставится в профиль вместо лендинга, это ровно то, чего быть не должно.

Скрипт пишет sibling-файл из чистого `dist/index.html`, стоит в `build` после KB-пререндера и **перед** `prerender-landing`, и падает с ошибкой, если запустить его позже. Страница несёт свой `<title>`, canonical, `og:type=profile` и JSON-LD **Person + ProfilePage** — именно по этой разметке площадка и поисковик отличают персональную страницу от лендинга.

## Мерка

`tests/prerender-alexey-semenov.test.mjs` — 8 проверок:

```
✓ место в build (после KB, до landing)
✓ роут зарегистрирован (иначе .html и приложение разойдутся)
✓ свой, не главной, <title> ≤ 60 симв. и description ≤ 158
✓ canonical + og:type=profile
✓ все три контакта — и в HTML-снимке, и в React-версии страницы
✓ разметка Person + ProfilePage
✓ страница НЕ читается как лендинг (нет тарифов/цен/«купить»/заявки)
✓ dist/index.html не мутирует; запуск после landing падает громко
8/8
```

Полная сеть: **422 теста, 13 красных — ровно те же 13, что и на `upstream/main` без этих правок** (сверено через `git stash`; это предсуществующие падения из-за отсутствия `php` в окружении). Новых красных нет.

Готовая страница проверена настоящей сборкой (`npm run build` → `dist/alexey-semenov.html`, 6.7 КБ).

## Что стоит решить вам

1. **Текст о себе** — я написал сдержанно и без непроверяемых утверждений; поправьте формулировки под себя, это ваша страница.
2. **Ссылка на профиль Хабра** со страницы — не ставил, потому что не знаю URL профиля; скажете — добавлю.
3. **sitemap.xml** — намеренно не трогал («вокруг ничего»). Если хотите, чтобы страница индексировалась, добавлю отдельной правкой.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
