### PR TITLE
fix(#555): форма поиска блога ведёт в /blog/search/, а не в движок Интеграма

### DIFF
--- a/blog-v2/src/pages/index.astro
+++ b/blog-v2/src/pages/index.astro
@@ -72,7 +72,7 @@ const archive = display.slice(10)
             системы без лишней разработки.
           </p>
 
-          <form class="product-blog-search" action="/search/" method="get" role="search">
+          <form class="product-blog-search" action={withBase("/search/")} method="get" role="search">
             <label class="sr-only" for="home-blog-search">Поиск по блогу</label>
             <input
               id="home-blog-search"

--- a/tests/issue-259-blog-product-newsroom.test.mjs
+++ b/tests/issue-259-blog-product-newsroom.test.mjs
@@ -19,7 +19,10 @@ test('blog home keeps product-blog basics after the issue 265 visual restyle', (
 
   assert.match(index, /product-blog-page/)
   assert.match(index, /product-blog-hero/)
-  assert.match(index, /action="\/search\/"/)
+  // Форма ведёт на страницу поиска блога. Адрес проверяем по смыслу, а не
+  // буквой: блог живёт в подпапке /blog/, и базу приклеивает withBase —
+  // буквальный «/search/» отправлял форму в корень ideav.ru (issue #555).
+  assert.match(index, /action=\{withBase\("\/search\/"\)\}/)
   assert.match(index, /name="q"/)
   assert.match(index, /product-blog-category-pills/)
   assert.match(index, /product-blog-featured/)

--- a/tests/issue-555-blog-base-links.test.mjs
+++ b/tests/issue-555-blog-base-links.test.mjs
@@ -1,0 +1,103 @@
+/**
+ * issue #555 — поиск по блогу кидал на экран авторизации Интеграма.
+ *
+ * Форма поиска на главной блога уходила по `action="/search/"`. Блог живёт в
+ * подпапке `/blog/` (issue #522), а вебрут ideav.ru общий с движком Интеграма:
+ * front controller шлёт всё, что не файл и не директория, в `index.php`, а
+ * движок читает первый сегмент пути как имя базы. Итог — «База «search» не
+ * найдена» и форма входа вместо результатов.
+ *
+ * Первопричина шире одной формы: `base` Astro подставляет только в свои ассеты
+ * и маршруты, рукописный путь он не трогает. В блоге для таких путей есть один
+ * помощник — `withBase()`. Тест сторожит именно это: ни один рукописный адрес
+ * от корня не должен обходить помощник. Проверка #522 сторожила наличие
+ * конфигурации, но не её сплошное применение — в эту щель баг и прошёл.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const repo = new URL('..', import.meta.url).pathname
+const blogSrc = join(repo, 'blog-v2/src')
+const read = (path) => readFileSync(join(repo, path), 'utf8')
+
+function sources(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    if (statSync(path).isDirectory()) sources(path, out)
+    else if (/\.(astro|ts)$/.test(name)) out.push(path)
+  }
+  return out
+}
+
+/**
+ * Литеральный путь от корня в атрибуте адреса: href="/…", action="/…", src="/…".
+ * Такой путь Astro отдаёт как есть — мимо базы. Написанный через помощник он
+ * выглядит иначе (`href={withBase("/…")}`) и под шаблон не попадает.
+ *
+ * Протокольные адреса (`//cdn…`) исключены: это внешние ссылки, база им не нужна.
+ */
+const LITERAL_ROOT_PATH = /(?:href|src|action|srcset|data-src)\s*=\s*"(\/(?!\/)[^"]*)"/g
+
+/**
+ * Комментарии выкидываем: в них такие адреса встречаются как пример — в том
+ * числе в документации самого `withBase`. Строчные `//` режем только когда
+ * строка с них начинается, иначе обрезался бы хвост строки после `https://…`
+ * и настоящее нарушение за внешней ссылкой осталось бы незамеченным.
+ */
+function stripComments(code) {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+}
+
+test('рукописные адреса блога не обходят withBase', () => {
+  const escaped = []
+
+  for (const file of sources(blogSrc)) {
+    const code = stripComments(readFileSync(file, 'utf8'))
+    for (const [, path] of code.matchAll(LITERAL_ROOT_PATH)) {
+      escaped.push(`${relative(repo, file)}: ${path}`)
+    }
+  }
+
+  assert.deepEqual(
+    escaped,
+    [],
+    'адрес от корня мимо withBase уйдёт в вебрут ideav.ru и попадёт движку Интеграма:\n' +
+      escaped.join('\n'),
+  )
+})
+
+test('форма поиска на главной блога ведёт в подпапку блога', () => {
+  const index = read('blog-v2/src/pages/index.astro')
+
+  assert.match(
+    index,
+    /<form[^>]*class="product-blog-search"[^>]*action=\{withBase\("\/search\/"\)\}/,
+    'action формы обязан приклеивать базу — иначе GET уходит на ideav.ru/search/',
+  )
+  assert.doesNotMatch(index, /action="\/search\/"/)
+})
+
+test('страница поиска принимает запрос из строки адреса', () => {
+  // Форма отправляется методом GET и передаёт запрос через ?q=. Если страница
+  // перестанет его читать, ссылка перестанет искать молча: поле будет пустым.
+  const search = read('blog-v2/src/pages/search.astro')
+
+  assert.match(read('blog-v2/src/pages/index.astro'), /method="get"/)
+  assert.match(search, /new URLSearchParams\(location\.search\)/)
+  assert.match(search, /params\.get\('q'\)/)
+})
+
+test('индекс поиска подгружается из подпапки блога', () => {
+  // pagefind лежит в /blog/pagefind/. Импорт по корневому пути ушёл бы движку
+  // ровно так же, как сама форма, — только молча, в консоли.
+  const search = read('blog-v2/src/pages/search.astro')
+
+  assert.match(search, /define:vars=\{\{ base: withBase\('\/'\) \}\}/)
+  assert.match(search, /import\(`\$\{base\}pagefind\/pagefind\.js`\)/)
+  assert.match(search, /baseUrl: base/)
+})


### PR DESCRIPTION
Закрывает #555.

## Что не так

Поиск на главной блога (https://ideav.ru/blog/) отправлял форму на `/search/` — и вместо результатов открывался экран входа Интеграма с «База «search» не найдена».

Первопричина не в поиске. Блог живёт в подпапке `/blog/` (#522), а вебрут ideav.ru общий с движком Интеграма: front controller шлёт всё, что не файл и не директория, в `index.php`, а движок читает первый сегмент пути как имя базы. `base` Astro подставляет только в свои ассеты и маршруты — рукописный путь он не трогает. В блоге для таких путей есть один помощник, `withBase()`; при переезде он дошёл всюду, кроме `action` этой формы. Соседняя ссылка «Открыть поиск» в том же файле (строка 175) уже была через помощник — поэтому поломка выглядела выборочной.

Замер живого сайта **до** правки:

| адрес | было |
|---|---|
| `/search/` | 302 → `start.html?db=search&r=dBNotExists` |
| `/blog/search/` | 200 |

## Что сделано

```diff
-<form class="product-blog-search" action="/search/" method="get" role="search">
+<form class="product-blog-search" action={withBase("/search/")} method="get" role="search">
```

## Другие подобные места — проверены, чисто

Правка одной строки закрывает симптом, но issue просит проверить класс. Проверял не глазами, а по собранному вебруту: `dist/` (React) + `dist/blog/` (Astro), как на проде.

- **Блог, весь собранный HTML.** Ни одного адреса от корня мимо базы: `grep '(href|src|action|srcset)="/…"' | grep -v '^/blog/'` → пусто. То же для `rss.xml`, `llms.txt`, `sitemap-0.xml`, `url()` в CSS и путей внутри inline-скриптов.
- **Весь сайт, 357 уникальных внутренних адресов** прогнаны через модель Apache (файл/директория → отдаётся; иначе → правила `.htaccess` выше front controller; иначе → движок). В движок уходит **один** адрес — `/start.html` со страницы `/acct.html`, и это ложное срабатывание: `start.html` отдаёт сама платформа из ideav/crm, в `dist/` этого репозитория его нет. На проде адрес живой.
- **Ссылки SPA.** Безрасширенных внутренних ссылок в `src/**/*.tsx` не осталось — обе оставшиеся ведут на `/excel-to-app.html#excel-form`, с расширением. Класс #551 со стороны ссылок закрыт; серверная часть (301 для входящих безрасширенных адресов) — предмет самого #551, здесь не трогаю.
- **Markdown статей.** remark-плагин приклеивает базу ко всем путям от корня, включая пути в inline-HTML; в собранном виде наружу не ушло ничего.

## Проверено

**В браузере**, на собранном вебруте (`dist/` + `dist/blog/`, статический сервер):

- ввод «минут» → Enter → `/blog/search/?q=минут`, запрос подставлен в поле, «Найдено: 75. Показано первых 25», подсветка совпадений;
- клик по первому результату → `/blog/posts/keis-masterskaya-rezki-rulonov-perestala-teryat-zakazy/`;
- индекс pagefind грузится с `/blog/pagefind/pagefind.js` — тоже через базу, консоль чистая.

**Тесты.** Новый `tests/issue-555-blog-base-links.test.mjs` держит инвариант, а не строку: ни один рукописный адрес от корня в `blog-v2/src` не обходит `withBase` (комментарии из проверки исключены — в документации самого помощника такие адреса стоят как пример). Плюс три точечные проверки: `action` формы приклеивает базу, страница поиска читает `?q=`, pagefind грузится из подпапки.

Тест проверен мутациями: вернуть `action="/search/"` → падает (2 проверки из 4); увести мимо базы чужой путь (`href="/rss.xml"` в `BaseLayout`) → падает.

Проверка #522 сторожила наличие настройки, но не сплошное её применение — в эту щель баг и прошёл; новый тест закрывает щель. Проверка #259 пиновала буквальный `action="/search/"`, то есть держала поломанное состояние — переписана на смысл.

`npm run build` зелёный (React + пререндер + `verify-htaccess`), сборка блога зелёная. `npm test`: 13 провалов, `comm` с прогоном на `origin/main` показывает **ноль новых** (все 13 — предсуществующие: PHP-окружение, контент статей, роут-тесты).

## ⚠️ Само по себе это issue не закроет — нужен деплой

У ideav.ru нет CI-деплоя. Пока `blog-v2/dist` не выложен, форма на живом сайте останется битой. Деплой overlay-ом, **без `rsync --delete`** — в том же вебруте лежит платформа из ideav/crm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
